### PR TITLE
fix: use unidirectional streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "err-code": "^2.0.0",
     "it-length-prefixed": "^3.0.0",
     "it-pipe": "^1.0.1",
-    "libp2p-pubsub": "^0.5.0",
+    "libp2p-pubsub": "libp2p/js-libp2p-pubsub#fix/use-unidirectional-streams",
     "p-map": "^4.0.0",
     "peer-id": "~0.13.3",
     "protons": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "err-code": "^2.0.0",
     "it-length-prefixed": "^3.0.0",
     "it-pipe": "^1.0.1",
-    "libp2p-pubsub": "libp2p/js-libp2p-pubsub#fix/use-unidirectional-streams",
+    "libp2p-pubsub": "~0.5.2",
     "p-map": "^4.0.0",
     "peer-id": "~0.13.3",
     "protons": "^1.0.1",

--- a/test/floodsub.spec.js
+++ b/test/floodsub.spec.js
@@ -112,11 +112,27 @@ describe('gossipsub fallbacks to floodsub', () => {
 
       const onConnectGs = registrarRecords[0][floodsubMulticodec].onConnect
       const onConnectFs = registrarRecords[1][floodsubMulticodec].onConnect
+      const handleGs = registrarRecords[0][floodsubMulticodec].handler
+      const handleFs = registrarRecords[1][floodsubMulticodec].handler
 
       // Notice peers of connection
       const [d0, d1] = ConnectionPair()
-      onConnectGs(nodeFs.peerId, d0)
-      onConnectFs(nodeGs.peerId, d1)
+      await onConnectGs(nodeFs.peerId, d0)
+      await handleFs({
+        protocol: floodsubMulticodec,
+        stream: d1.stream,
+        connection: {
+          remotePeer: nodeGs.peerId
+        }
+      })
+      await onConnectFs(nodeGs.peerId, d1)
+      await handleGs({
+        protocol: floodsubMulticodec,
+        stream: d0.stream,
+        connection: {
+          remotePeer: nodeFs.peerId
+        }
+      })
     })
 
     after(async function () {
@@ -167,11 +183,27 @@ describe('gossipsub fallbacks to floodsub', () => {
 
       const onConnectGs = registrarRecords[0][floodsubMulticodec].onConnect
       const onConnectFs = registrarRecords[1][floodsubMulticodec].onConnect
+      const handleGs = registrarRecords[0][floodsubMulticodec].handler
+      const handleFs = registrarRecords[1][floodsubMulticodec].handler
 
       // Notice peers of connection
       const [d0, d1] = ConnectionPair()
-      onConnectGs(nodeFs.peerId, d0)
-      onConnectFs(nodeGs.peerId, d1)
+      await onConnectGs(nodeFs.peerId, d0)
+      await handleFs({
+        protocol: floodsubMulticodec,
+        stream: d1.stream,
+        connection: {
+          remotePeer: nodeGs.peerId
+        }
+      })
+      await onConnectFs(nodeGs.peerId, d1)
+      await handleGs({
+        protocol: floodsubMulticodec,
+        stream: d0.stream,
+        connection: {
+          remotePeer: nodeFs.peerId
+        }
+      })
 
       nodeGs.subscribe(topic)
       nodeFs.subscribe(topic)
@@ -288,11 +320,27 @@ describe('gossipsub fallbacks to floodsub', () => {
 
       const onConnectGs = registrarRecords[0][floodsubMulticodec].onConnect
       const onConnectFs = registrarRecords[1][floodsubMulticodec].onConnect
+      const handleGs = registrarRecords[0][floodsubMulticodec].handler
+      const handleFs = registrarRecords[1][floodsubMulticodec].handler
 
       // Notice peers of connection
       const [d0, d1] = ConnectionPair()
       await onConnectGs(nodeFs.peerId, d0)
+      await handleFs({
+        protocol: floodsubMulticodec,
+        stream: d1.stream,
+        connection: {
+          remotePeer: nodeGs.peerId
+        }
+      })
       await onConnectFs(nodeGs.peerId, d1)
+      await handleGs({
+        protocol: floodsubMulticodec,
+        stream: d0.stream,
+        connection: {
+          remotePeer: nodeFs.peerId
+        }
+      })
 
       nodeGs.subscribe(topic)
       nodeFs.subscribe(topic)

--- a/test/gossip.js
+++ b/test/gossip.js
@@ -32,7 +32,7 @@ describe('gossip', () => {
     // add subscriptions to each node
     nodes.forEach((n) => n.subscribe(topic))
 
-    connectGossipsubNodes(nodes, registrarRecords, multicodec)
+    await connectGossipsubNodes(nodes, registrarRecords, multicodec)
 
     await new Promise((resolve) => setTimeout(resolve, 1000))
 
@@ -69,7 +69,7 @@ describe('gossip', () => {
     nodes.forEach((n) => n.subscribe(topic))
 
     // every node connected to every other
-    connectGossipsubNodes(nodes, registrarRecords, multicodec)
+    await connectGossipsubNodes(nodes, registrarRecords, multicodec)
     await new Promise((resolve) => setTimeout(resolve, 500))
     // await mesh rebalancing
     await Promise.all(nodes.map((n) => new Promise((resolve) => n.once('gossipsub:heartbeat', resolve))))

--- a/test/mesh.spec.js
+++ b/test/mesh.spec.js
@@ -35,15 +35,31 @@ describe('mesh overlay', () => {
     // connect N (< GossipsubD) nodes to node0
     const N = 4
     const onConnect0 = registrarRecords[0][multicodec].onConnect
+    const handle0 = registrarRecords[0][multicodec].handler
 
     for (let i = nodes.length; i > nodes.length - N; i--) {
       const n = i - 1
       const onConnectN = registrarRecords[n][multicodec].onConnect
+      const handleN = registrarRecords[n][multicodec].handler
 
       // Notice peers of connection
       const [d0, d1] = ConnectionPair()
-      onConnect0(nodes[n].peerId, d0)
-      onConnectN(nodes[0].peerId, d1)
+      await onConnect0(nodes[n].peerId, d0)
+      await handleN({
+        protocol: multicodec,
+        stream: d1.stream,
+        connection: {
+          remotePeer: nodes[0].peerId
+        }
+      })
+      await onConnectN(nodes[0].peerId, d1)
+      await handle0({
+        protocol: multicodec,
+        stream: d0.stream,
+        connection: {
+          remotePeer: nodes[n].peerId
+        }
+      })
     }
 
     // await mesh rebalancing

--- a/test/multiple-nodes.spec.js
+++ b/test/multiple-nodes.spec.js
@@ -38,15 +38,46 @@ describe('multiple nodes (more than 2)', () => {
           const onConnectA = registrarRecords[0][multicodec].onConnect
           const onConnectB = registrarRecords[1][multicodec].onConnect
           const onConnectC = registrarRecords[2][multicodec].onConnect
+          const handleA = registrarRecords[0][multicodec].handler
+          const handleB = registrarRecords[1][multicodec].handler
+          const handleC = registrarRecords[2][multicodec].handler
 
           // Notice peers of connection
           const [d0, d1] = ConnectionPair()
-          onConnectA(b.peerId, d0)
-          onConnectB(a.peerId, d1)
+          await onConnectA(b.peerId, d0)
+          await handleB({
+            protocol: multicodec,
+            stream: d1.stream,
+            connection: {
+              remotePeer: a.peerId
+            }
+          })
+          await onConnectB(a.peerId, d1)
+          await handleA({
+            protocol: multicodec,
+            stream: d0.stream,
+            connection: {
+              remotePeer: b.peerId
+            }
+          })
 
           const [d2, d3] = ConnectionPair()
-          onConnectB(c.peerId, d2)
-          onConnectC(b.peerId, d3)
+          await onConnectB(c.peerId, d2)
+          await handleC({
+            protocol: multicodec,
+            stream: d3.stream,
+            connection: {
+              remotePeer: b.peerId
+            }
+          })
+          await onConnectC(b.peerId, d3)
+          await handleB({
+            protocol: multicodec,
+            stream: d2.stream,
+            connection: {
+              remotePeer: c.peerId
+            }
+          })
         })
 
         after(() => Promise.all(nodes.map((n) => n.stop())))
@@ -103,15 +134,46 @@ describe('multiple nodes (more than 2)', () => {
           const onConnectA = registrarRecords[0][multicodec].onConnect
           const onConnectB = registrarRecords[1][multicodec].onConnect
           const onConnectC = registrarRecords[2][multicodec].onConnect
+          const handleA = registrarRecords[0][multicodec].handler
+          const handleB = registrarRecords[1][multicodec].handler
+          const handleC = registrarRecords[2][multicodec].handler
 
           // Notice peers of connection
           const [d0, d1] = ConnectionPair()
-          onConnectA(b.peerId, d0)
-          onConnectB(a.peerId, d1)
+          await onConnectA(b.peerId, d0)
+          await handleB({
+            protocol: multicodec,
+            stream: d1.stream,
+            connection: {
+              remotePeer: a.peerId
+            }
+          })
+          await onConnectB(a.peerId, d1)
+          await handleA({
+            protocol: multicodec,
+            stream: d0.stream,
+            connection: {
+              remotePeer: b.peerId
+            }
+          })
 
           const [d2, d3] = ConnectionPair()
-          onConnectB(c.peerId, d2)
-          onConnectC(b.peerId, d3)
+          await onConnectB(c.peerId, d2)
+          await handleC({
+            protocol: multicodec,
+            stream: d3.stream,
+            connection: {
+              remotePeer: b.peerId
+            }
+          })
+          await onConnectC(b.peerId, d3)
+          await handleB({
+            protocol: multicodec,
+            stream: d2.stream,
+            connection: {
+              remotePeer: c.peerId
+            }
+          })
 
           a.subscribe(topic)
           b.subscribe(topic)
@@ -198,15 +260,46 @@ describe('multiple nodes (more than 2)', () => {
         const onConnectA = registrarRecords[0][multicodec].onConnect
         const onConnectB = registrarRecords[1][multicodec].onConnect
         const onConnectC = registrarRecords[2][multicodec].onConnect
+        const handleA = registrarRecords[0][multicodec].handler
+        const handleB = registrarRecords[1][multicodec].handler
+        const handleC = registrarRecords[2][multicodec].handler
 
         // Notice peers of connection
         const [d0, d1] = ConnectionPair()
-        onConnectA(b.peerId, d0)
-        onConnectB(a.peerId, d1)
+        await onConnectA(b.peerId, d0)
+        await handleB({
+          protocol: multicodec,
+          stream: d1.stream,
+          connection: {
+            remotePeer: a.peerId
+          }
+        })
+        await onConnectB(a.peerId, d1)
+        await handleA({
+          protocol: multicodec,
+          stream: d0.stream,
+          connection: {
+            remotePeer: b.peerId
+          }
+        })
 
         const [d2, d3] = ConnectionPair()
-        onConnectB(c.peerId, d2)
-        onConnectC(b.peerId, d3)
+        await onConnectB(c.peerId, d2)
+        await handleC({
+          protocol: multicodec,
+          stream: d3.stream,
+          connection: {
+            remotePeer: b.peerId
+          }
+        })
+        await onConnectC(b.peerId, d3)
+        await handleB({
+          protocol: multicodec,
+          stream: d2.stream,
+          connection: {
+            remotePeer: c.peerId
+          }
+        })
 
         a.subscribe(topic)
         b.subscribe(topic)
@@ -264,22 +357,84 @@ describe('multiple nodes (more than 2)', () => {
         const onConnectD = registrarRecords[3][multicodec].onConnect
         const onConnectE = registrarRecords[4][multicodec].onConnect
 
+        const handleA = registrarRecords[0][multicodec].handler
+        const handleB = registrarRecords[1][multicodec].handler
+        const handleC = registrarRecords[2][multicodec].handler
+        const handleD = registrarRecords[3][multicodec].handler
+        const handleE = registrarRecords[4][multicodec].handler
+
         // Notice peers of connection
         const [d0, d1] = ConnectionPair()
-        onConnectA(b.peerId, d0)
-        onConnectB(a.peerId, d1)
+        await onConnectA(b.peerId, d0)
+        await handleB({
+          protocol: multicodec,
+          stream: d1.stream,
+          connection: {
+            remotePeer: a.peerId
+          }
+        })
+        await onConnectB(a.peerId, d1)
+        await handleA({
+          protocol: multicodec,
+          stream: d0.stream,
+          connection: {
+            remotePeer: b.peerId
+          }
+        })
 
         const [d2, d3] = ConnectionPair()
-        onConnectB(c.peerId, d2)
-        onConnectC(b.peerId, d3)
+        await onConnectB(c.peerId, d2)
+        await handleC({
+          protocol: multicodec,
+          stream: d3.stream,
+          connection: {
+            remotePeer: b.peerId
+          }
+        })
+        await onConnectC(b.peerId, d3)
+        await handleB({
+          protocol: multicodec,
+          stream: d2.stream,
+          connection: {
+            remotePeer: c.peerId
+          }
+        })
 
         const [d4, d5] = ConnectionPair()
-        onConnectC(d.peerId, d4)
-        onConnectD(c.peerId, d5)
+        await onConnectC(d.peerId, d4)
+        await handleD({
+          protocol: multicodec,
+          stream: d5.stream,
+          connection: {
+            remotePeer: c.peerId
+          }
+        })
+        await onConnectD(c.peerId, d5)
+        await handleC({
+          protocol: multicodec,
+          stream: d4.stream,
+          connection: {
+            remotePeer: d.peerId
+          }
+        })
 
         const [d6, d7] = ConnectionPair()
-        onConnectD(e.peerId, d6)
-        onConnectE(d.peerId, d7)
+        await onConnectD(e.peerId, d6)
+        await handleE({
+          protocol: multicodec,
+          stream: d7.stream,
+          connection: {
+            remotePeer: d.peerId
+          }
+        })
+        await onConnectE(d.peerId, d7)
+        await handleD({
+          protocol: multicodec,
+          stream: d6.stream,
+          connection: {
+            remotePeer: e.peerId
+          }
+        })
 
         a.subscribe(topic)
         b.subscribe(topic)

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -6,12 +6,10 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 const sinon = require('sinon')
-const pWaitFor = require('p-wait-for')
 
 const { utils } = require('libp2p-pubsub')
 const {
   createGossipsub,
-  createPeerId,
   mockRegistrar
 } = require('./utils')
 
@@ -120,36 +118,6 @@ describe('Pubsub', () => {
         expect(gossipsub._processRpcMessage.callCount).to.eql(1)
         resolve()
       }, 500))
-    })
-  })
-
-  describe('process', () => {
-    it('should disconnect peer on stream error', async () => {
-      sinon.spy(gossipsub, '_onPeerDisconnected')
-
-      const peerId = await createPeerId()
-      const mockConn = {
-        newStream () {
-          return {
-            stream: {
-              sink: async source => {
-                for await (const _ of source) { // eslint-disable-line no-unused-vars
-                  // mock stream just swallows any data sent
-                }
-              },
-              source: (async function * () { // eslint-disable-line require-yield
-                // throw in a bit
-                await new Promise(resolve => setTimeout(resolve, 100))
-                throw new Error('boom')
-              })()
-            }
-          }
-        }
-      }
-
-      gossipsub._onPeerConnected(peerId, mockConn)
-
-      await pWaitFor(() => gossipsub._onPeerDisconnected.calledWith(peerId), { timeout: 1000 })
     })
   })
 

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -54,17 +54,34 @@ const createGossipsubNodes = async (n, shouldStart, options) => {
 
 exports.createGossipsubNodes = createGossipsubNodes
 
-const connectGossipsubNodes = (nodes, registrarRecords, multicodec) => {
+const connectGossipsubNodes = async (nodes, registrarRecords, multicodec) => {
   // connect all nodes
   for (let i = 0; i < nodes.length; i++) {
     for (let j = i + 1; j < nodes.length; j++) {
       const onConnectI = registrarRecords[i][multicodec].onConnect
       const onConnectJ = registrarRecords[j][multicodec].onConnect
 
+      const handleI = registrarRecords[i][multicodec].handler
+      const handleJ = registrarRecords[j][multicodec].handler
+
       // Notice peers of connection
       const [d0, d1] = ConnectionPair()
-      onConnectI(nodes[j].peerId, d0)
-      onConnectJ(nodes[i].peerId, d1)
+      await onConnectI(nodes[j].peerId, d0)
+      await handleJ({
+        protocol: multicodec,
+        stream: d1.stream,
+        connection: {
+          remotePeer: nodes[i].peerId
+        }
+      })
+      await onConnectJ(nodes[i].peerId, d1)
+      await handleI({
+        protocol: multicodec,
+        stream: d0.stream,
+        connection: {
+          remotePeer: nodes[j].peerId
+        }
+      })
     }
   }
 


### PR DESCRIPTION
This PR makes libp2p pubsub subsystem use unidirectional streams instead of bidirectional streams per discussion on [ipfs/go-ipfs#7390](https://github.com/ipfs/go-ipfs/issues/7390).

More details about the reasoning for this can be found in https://discuss.libp2p.io/t/gossip-questions/257/6

I have tested this change on all libp2p repos: `js-libp2p`, `libp2p-daemon` and `interop` and everything is working properly. The tests here need to be updated though, as a result of the tests being implemented considering a bidirectional stream.

Bear in mind that a lot of this "connection logic" can be abstracted. I did not worry about it and just followed what we already had in floodsub and gossipsub. Hopefully, after `gossipsub@1.1`, I want to create the libp2p pubsub interface and move/refactor the tests there and re-use most of them in all our router implementations.

Needs:

- [ ] https://github.com/libp2p/js-libp2p-pubsub/pull/45