### PR TITLE
gs1.1 flood publishing

### DIFF
--- a/ts/getGossipPeers.ts
+++ b/ts/getGossipPeers.ts
@@ -1,27 +1,38 @@
-import * as constants from './constants'
+import { GossipsubIDv10, GossipsubIDv11 } from './constants'
 import { shuffle } from './utils'
 import { Peer } from './peer'
 import Gossipsub = require('./index')
 
 /**
  * Given a topic, returns up to count peers subscribed to that topic
+ * that pass an optional filter function
  *
  * @param {Gossipsub} router
  * @param {String} topic
  * @param {Number} count
+ * @param {Function} [filter] a function to filter acceptable peers
  * @returns {Set<Peer>}
  *
  */
-export function getGossipPeers (router: Gossipsub, topic: string, count: number): Set<Peer> {
+export function getGossipPeers (
+  router: Gossipsub,
+  topic: string,
+  count: number,
+  filter: (peer: Peer) => boolean = () => true
+): Set<Peer> {
   const peersInTopic = router.topics.get(topic)
   if (!peersInTopic) {
     return new Set()
   }
 
   // Adds all peers using our protocol
+  // that also pass the filter function
   let peers: Peer[] = []
   peersInTopic.forEach((peer) => {
-    if (peer.protocols.includes(constants.GossipsubIDv10)) {
+    if (
+      peer.protocols.find(proto => proto === GossipsubIDv10 || proto === GossipsubIDv11) &&
+      filter(peer)
+    ) {
       peers.push(peer)
     }
   })


### PR DESCRIPTION
Builds off #87 
Implements https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#flood-publishing

Add `floodPublish` option, defaulted to true
With flood publishing on:
Self-published messages should be sent to all peers with scores above the publish threshold

With flood publishing off:
Self-published messages should be sent using gossipsub 1.0 functionality