### PR TITLE
gs1.1 outbound mesh quota

### DIFF
--- a/ts/heartbeat.ts
+++ b/ts/heartbeat.ts
@@ -75,52 +75,157 @@ export class Heartbeat {
     // that hasn't been piggybacked since the last heartbeat
     this.gossipsub._flush()
 
-    /**
-     * @type {Map<Peer, Array<String>>}
-     */
+    // cache scores throught the heartbeat
+    const scores = new Map<string, number>()
+    const getScore = (id: string): number => {
+      let s = scores.get(id)
+      if (s === undefined) {
+        s = this.gossipsub.score.score(id)
+        scores.set(id, s)
+      }
+      return s
+    }
+
     const tograft = new Map<Peer, string[]>()
     const toprune = new Map<Peer, string[]>()
 
     // maintain the mesh for topics we have joined
     this.gossipsub.mesh.forEach((peers, topic) => {
+      // prune/graft helper functions (defined per topic)
+      const prunePeer = (p: Peer): void => {
+        const id = p.id.toB58String()
+        this.gossipsub.log(
+          'HEARTBEAT: Remove mesh link to %s in %s',
+          id, topic
+        )
+        // update peer score
+        this.gossipsub.score.prune(id, topic)
+        // remove peer from mesh
+        peers.delete(p)
+        // add to toprune
+        const topics = toprune.get(p)
+        if (!topics) {
+          toprune.set(p, [topic])
+        } else {
+          topics.push(topic)
+        }
+      }
+      const graftPeer = (p: Peer): void => {
+        const id = p.id.toB58String()
+        this.gossipsub.log(
+          'HEARTBEAT: Add mesh link to %s in %s',
+          id, topic
+        )
+        // update peer score
+        this.gossipsub.score.graft(id, topic)
+        // add peer to mesh
+        peers.add(p)
+        // add to tograft
+        const topics = tograft.get(p)
+        if (!topics) {
+          tograft.set(p, [topic])
+        } else {
+          topics.push(topic)
+        }
+      }
+
+      // drop all peers with negative score
+      peers.forEach(p => {
+        const id = p.id.toB58String()
+        const score = getScore(id)
+        if (score < 0) {
+          this.gossipsub.log(
+            'HEARTBEAT: Prune peer %s with negative score: score=%d, topic=%s',
+            id, score, topic
+          )
+          prunePeer(p)
+        }
+      })
+
       // do we have enough peers?
       if (peers.size < constants.GossipsubDlo) {
         const ineed = constants.GossipsubD - peers.size
-        const peersSet = getGossipPeers(this.gossipsub, topic, ineed)
-        peersSet.forEach((peer) => {
-          // add topic peers not already in mesh
-          if (peers.has(peer)) {
-            return
-          }
-
-          this.gossipsub.log('HEARTBEAT: Add mesh link to %s in %s', peer.id.toB58String(), topic)
-          peers.add(peer)
-          const peerGrafts = tograft.get(peer)
-          if (!peerGrafts) {
-            tograft.set(peer, [topic])
-          } else {
-            peerGrafts.push(topic)
-          }
+        const peersSet = getGossipPeers(this.gossipsub, topic, ineed, p => {
+          // filter out mesh peers, peers with negative score
+          return !peers.has(p) && getScore(p.id.toB58String()) >= 0
         })
+
+        peersSet.forEach(graftPeer)
       }
 
       // do we have to many peers?
       if (peers.size > constants.GossipsubDhi) {
-        const idontneed = peers.size - constants.GossipsubD
         let peersArray = Array.from(peers)
-        peersArray = shuffle(peersArray)
-        peersArray = peersArray.slice(0, idontneed)
+        // sort by score
+        peersArray.sort((a, b) => getScore(b.id.toB58String()) - getScore(a.id.toB58String()))
+        // We keep the first D_score peers by score and the remaining up to D randomly
+        // under the constraint that we keep D_out peers in the mesh (if we have that many)
+        peersArray = peersArray.slice(0, constants.GossipsubDscore).concat(
+          shuffle(peersArray.slice(constants.GossipsubDscore))
+        )
 
-        peersArray.forEach((peer) => {
-          this.gossipsub.log('HEARTBEAT: Remove mesh link to %s in %s', peer.id.toB58String(), topic)
-          peers.delete(peer)
-          const peerPrunes = toprune.get(peer)
-          if (!peerPrunes) {
-            toprune.set(peer, [topic])
-          } else {
-            peerPrunes.push(topic)
+        // count the outbound peers we are keeping
+        let outbound = 0
+        peersArray.slice(0, constants.GossipsubD).forEach(p => {
+          if (this.gossipsub.outbound.get(p)) {
+            outbound++
           }
         })
+
+        // if it's less than D_out, bubble up some outbound peers from the random selection
+        if (outbound < constants.GossipsubDout) {
+          const rotate = (i: number): void => {
+            // rotate the peersArray to the right and put the ith peer in the front
+            const p = peersArray[i]
+            for (let j = i; j > 0; j--) {
+              peersArray[j] = peersArray[j - 1]
+            }
+            peersArray[0] = p
+          }
+
+          // first bubble up all outbound peers already in the selection to the front
+          if (outbound > 0) {
+            let ihave = outbound
+            for (let i = 1; i < constants.GossipsubD && ihave > 0; i++) {
+              if (this.gossipsub.outbound.get(peersArray[i])) {
+                rotate(i)
+                ihave--
+              }
+            }
+          }
+
+          // now bubble up enough outbound peers outside the selection to the front
+          let ineed = constants.GossipsubD - outbound
+          for (let i = constants.GossipsubD; i < peersArray.length && ineed > 0; i++) {
+            if (this.gossipsub.outbound.get(peersArray[i])) {
+              rotate(i)
+              ineed--
+            }
+          }
+        }
+
+        // prune the excess peers
+        peersArray.slice(0, constants.GossipsubD).forEach(prunePeer)
+      }
+
+      // do we have enough outbound peers?
+      if (peers.size >= constants.GossipsubDlo) {
+        // count the outbound peers we have
+        let outbound = 0
+        peers.forEach(p => {
+          if (this.gossipsub.outbound.get(p)) {
+            outbound++
+          }
+        })
+
+        // if it's less than D_out, select some peers with outbound connections and graft them
+        if (outbound < constants.GossipsubDout) {
+          const ineed = constants.GossipsubDout - outbound
+          getGossipPeers(this.gossipsub, topic, ineed, (p: Peer): boolean => {
+            // filter our current mesh peers and peers with negative score
+            return !peers.has(p) && getScore(p.id.toB58String()) >= 0
+          }).forEach(graftPeer)
+        }
       }
 
       this.gossipsub._emitGossip(topic, peers)

--- a/ts/score/peerScore.ts
+++ b/ts/score/peerScore.ts
@@ -14,10 +14,14 @@ const log = debug('libp2p:gossipsub:score')
 interface Connection {
   remoteAddr: Multiaddr
   remotePeer: PeerId
+  stat: {
+    direction: 'inbound' | 'outbound'
+  }
+  registry: Map<string, {protocol: string}>
 }
 
 export interface ConnectionManager {
-  getAll(id: string): Connection[]
+  getAll(peerId: PeerId): Connection[]
   // eslint-disable-next-line @typescript-eslint/ban-types
   on(evt: string, fn: Function): void
   // eslint-disable-next-line @typescript-eslint/ban-types
@@ -518,7 +522,7 @@ export class PeerScore {
    * @returns {Array<string>}
    */
   _getIPs (id: string): string[] {
-    return this._connectionManager.getAll(id)
+    return this._connectionManager.getAll(PeerId.createFromB58String(id))
       .map(c => c.remoteAddr.toOptions().host)
   }
 


### PR DESCRIPTION
Implements
https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#outbound-mesh-quotas
https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#heartbeat-maintenance
https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#spam-protection-measures `GRAFT` spam protection

Most of these edits made directly in line with the go-libp2p-pubsub impl. https://github.com/libp2p/go-libp2p-pubsub/blob/master/gossipsub.go
I tried to avoid rewriting / adding all features, so there are some conditionals/blocks that aren't yet included (eg: direct peers, graft/prune backoff tracking, px, etc)

Big updates:
`_addPeer`, `_removePeer`
- add/remove `outbound` cache for peer

`_handleGraft`
- update to ignore negative score peer grafts
- only accept outbound grafts if over Dhi

`heartbeat`
- cache score
- graftPeer, prunePeer inline functions
- heartbeat maintenance and outbound mesh quota additions

`test/gossip.js`
- tweak second test to be... better