### PR TITLE
gs1.1 extended validators

### DIFF
--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -138,7 +138,6 @@ describe('Pubsub', () => {
       sinon.stub(gossipsub.peers, 'get').returns({})
       const filteredTopic = 't'
       const peer = new Peer({ id: await PeerId.create() })
-      //gossipsub.peers.set(peer.id.toB58String(), peer)
 
       // Set a trivial topic validator
       gossipsub.topicValidators.set(filteredTopic, (topic, peer, message) => {

--- a/ts/constants.ts
+++ b/ts/constants.ts
@@ -206,3 +206,9 @@ export const GossipsubMaxIHaveMessages = 10
 export const GossipsubIWantFollowupTime = 3 * second
 
 export const TimeCacheDuration = 120 * 1000
+
+export const enum ExtendedValidatorResult {
+  accept = 'accept',
+  reject = 'reject',
+  ignore = 'ignore'
+}


### PR DESCRIPTION
Implements https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#extended-validators

Add extended topic validators and minimal refactoring to properly support it
Integrate scoring for validation (validation begin/reject/ignore), and successful message delivery

`src/pubsub.js` required some refactoring to support this feature. The main reason is that messages should first be checked for `seenCache` entries before running topic validation. Since the `seenCache` is currently on the gossipsub layer, and validation on the pubsub layer, there was some reworking to allow `seenCache` to checked before validation -- namely, moving validation from `_processRpc`, as a pre-step to `_processRpcMessage`, to instead run validation within `_processRpcMessage`. (See https://github.com/libp2p/js-libp2p-pubsub/issues/50 and #92 for wrinkles still lingering) 

This required some refactoring of the pubsub tests within this repo.

`src/pubsub.js` also got some slight refactoring around emitting messages.
`_emitMessage` now takes a single parameter (a InMessage), and is reused in both self publishing and publishing from received messages.
`_processRpcMessage` was extended with an additional method `_publishFrom`, which is meant to act as the "success case" for messages received from peers (step 7 in #92). This method is now extended on the gossipsub layer to broadcast messages to floodsub/mesh peers and support "message delivered" peer scoring.