### PR TITLE
gs1.1 adaptive gossip

### DIFF
--- a/ts/getGossipPeers.ts
+++ b/ts/getGossipPeers.ts
@@ -1,5 +1,4 @@
-import { GossipsubIDv10, GossipsubIDv11 } from './constants'
-import { shuffle } from './utils'
+import { shuffle, hasGossipProtocol } from './utils'
 import { Peer } from './peer'
 import Gossipsub = require('./index')
 
@@ -30,7 +29,7 @@ export function getGossipPeers (
   let peers: Peer[] = []
   peersInTopic.forEach((peer) => {
     if (
-      peer.protocols.find(proto => proto === GossipsubIDv10 || proto === GossipsubIDv11) &&
+      hasGossipProtocol(peer.protocols) &&
       filter(peer)
     ) {
       peers.push(peer)

--- a/ts/utils/hasGossipProtocol.ts
+++ b/ts/utils/hasGossipProtocol.ts
@@ -1,0 +1,7 @@
+import { GossipsubIDv10, GossipsubIDv11 } from '../constants'
+
+export function hasGossipProtocol (protocols: string[]): boolean {
+  return Boolean(protocols.find(p =>
+    p === GossipsubIDv10 || p === GossipsubIDv11
+  ))
+}

--- a/ts/utils/index.ts
+++ b/ts/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './createGossipRpc'
 export * from './shuffle'
+export * from './hasGossipProtocol'


### PR DESCRIPTION
Implements https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#adaptive-gossip-dissemination

- Closely follows the go-libp2p-pubsub implementation
- Adaptive gossip dissemination in `_emitGossip`
- fixes up the fanout peer handling in `heartbeat`
  - includes bugfix in the heartbeat where we were deleting fanout peers who _are_ still in the topic (yikes)
- Add `hasGossipProtocol` utility function, replace where appropriate