### PR TITLE
gs1.1 pruning backoff

### DIFF
--- a/ts/constants.ts
+++ b/ts/constants.ts
@@ -140,6 +140,12 @@ export const GossipsubPrunePeers = 16
 export const GossipsubPruneBackoff = minute
 
 /**
+ * GossipsubPruneBackoffTicks is the number of heartbeat ticks for attempting to prune expired
+ * backoff timers.
+ */
+export const GossipsubPruneBackoffTicks = 15
+
+/**
  * GossipsubConnectors controls the number of active connection attempts for peers obtained through PX.
  */
 export const GossipsubConnectors = 8

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -542,8 +542,8 @@ class Gossipsub extends BasicPubsub {
    * @returns {void}
    */
   _clearBackoff (): void {
-    // we only clear once every 15 ticks to avoid iterating over the maps too much
-    if (this.heartbeatTicks % 15 !== 0) {
+    // we only clear once every GossipsubPruneBackoffTicks ticks to avoid iterating over the maps too much
+    if (this.heartbeatTicks % constants.GossipsubPruneBackoffTicks !== 0) {
       return
     }
 

--- a/ts/message/index.ts
+++ b/ts/message/index.ts
@@ -104,6 +104,13 @@ export interface ControlGraft {
  */
 export interface ControlPrune {
   topicID?: string
+  peers: PeerInfo[]
+  backoff?: number
+}
+
+export interface PeerInfo {
+  peerID?: Buffer
+  signedPeerRecord?: Buffer
 }
 
 /**

--- a/ts/message/rpc.proto.ts
+++ b/ts/message/rpc.proto.ts
@@ -40,5 +40,12 @@ message RPC {
 
   message ControlPrune {
     optional string topicID = 1;
+    repeated PeerInfo peers = 2;
+    optional uint64 backoff = 3;
+  }
+
+  message PeerInfo {
+    optional bytes peerID = 1;
+    optional bytes signedPeerRecord = 2;
   }
 }`


### PR DESCRIPTION
Implements https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#prune-backoff-and-peer-exchange prune backoff, not peer exchange

Follows the go-libp2p-pubsub implementation closely.

Extends `ControlPrune` protobuf message and interface to include "peer info"s and backoff. (For now, only backoff is used)
Adds `backoff` Map, a map of maps, indexed by topic, then peer, with a value of a timestamp. If a peer sends a graft for a topic while a backoff entry exists, immediately prune, re-extend the backoff period.
Adds a `heartbeatTicks` counter, will be used for opportunistic grafting in a future PR. Here it's used to clear old backoff entries once every 15 heartbeats.
Adds a `_makePrune` `ControlPrune` constructor. For now, the PX section is not there.