### PR TITLE
gs1.1: use publishThreshold for floodsub fallback peers

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -765,7 +765,8 @@ class Gossipsub extends BasicPubsub {
 
           // floodsub peers
           peersInTopic.forEach((peer) => {
-            if (peer.protocols.includes(constants.FloodsubID)) {
+            const score = this.score.score(peer.id.toB58String())
+            if (peer.protocols.includes(constants.FloodsubID) && score >= this._options.scoreThresholds.publishThreshold) {
               tosend.add(peer)
             }
           })


### PR DESCRIPTION
We should check a peer's score against the publishThreshold even if they are a floodsub peer.
This was missed in integrating the scoring into gossipsub.

Caught looking at go-libp2p-pubsub implementaiton