### PR TITLE
gs1.1: feat: track ihave/iwant counts

### DIFF
--- a/ts/heartbeat.ts
+++ b/ts/heartbeat.ts
@@ -90,6 +90,10 @@ export class Heartbeat {
     // clean up expired backoffs
     this.gossipsub._clearBackoff()
 
+    // clean up peerhave/iasked counters
+    this.gossipsub.peerhave.clear()
+    this.gossipsub.iasked.clear()
+
     // ensure direct peers are connected
     this.gossipsub._directConnect()
 


### PR DESCRIPTION
Implements https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#spam-protection-measures IWANT and IHAVE limiting

Closely follows go-libp2p-pubsub impl