### PR TITLE
fix: connected with a subscriber before a mesh is created should send

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -518,7 +518,7 @@ class Gossipsub extends BasicPubsub {
 
         // Gossipsub peers handling
         let meshPeers = this.mesh.get(topic)
-        if (!meshPeers) {
+        if (!meshPeers || !meshPeers.size) {
           // We are not in the mesh for topic, use fanout peers
           meshPeers = this.fanout.get(topic)
           if (!meshPeers) {


### PR DESCRIPTION
@jacobheun discovered this bug where if we're connected to a subscriber before the mesh is formed, we don't send them messages.