### PR TITLE
gs1.1: use string peer id consistently

### DIFF
--- a/test/2-nodes.spec.js
+++ b/test/2-nodes.spec.js
@@ -113,8 +113,8 @@ describe('2 nodes', () => {
         new Promise((resolve) => nodes[1].once('gossipsub:heartbeat', resolve))
       ])
 
-      expect(first(nodes[0].mesh.get(topic)).id.toB58String()).to.equal(first(nodes[0].peers).id.toB58String())
-      expect(first(nodes[1].mesh.get(topic)).id.toB58String()).to.equal(first(nodes[1].peers).id.toB58String())
+      expect(first(nodes[0].mesh.get(topic))).to.equal(first(nodes[0].peers).id.toB58String())
+      expect(first(nodes[1].mesh.get(topic))).to.equal(first(nodes[1].peers).id.toB58String())
     })
   })
 

--- a/test/gossip.spec.js
+++ b/test/gossip.spec.js
@@ -47,10 +47,9 @@ describe('gossip', () => {
 
     nodeA._pushGossip.getCalls()
       .map((call) => call.args[0])
-      .forEach((peer) => {
-        const peerId = peer.id.toB58String()
-        nodeA.mesh.get(topic).forEach((meshPeer) => {
-          expect(meshPeer.id.toB58String()).to.not.equal(peerId)
+      .forEach((peerId) => {
+        nodeA.mesh.get(topic).forEach((meshPeerId) => {
+          expect(meshPeerId).to.not.equal(peerId)
         })
       })
 
@@ -74,7 +73,7 @@ describe('gossip', () => {
     await delay(500)
 
     const peerB = first(nodeA.mesh.get(topic))
-    const nodeB = nodes.find((n) => n.peerId.toB58String() === peerB.id.toB58String())
+    const nodeB = nodes.find((n) => n.peerId.toB58String() === peerB)
 
     // set spy
     sinon.spy(nodeA, '_piggybackControl')

--- a/ts/getGossipPeers.ts
+++ b/ts/getGossipPeers.ts
@@ -1,5 +1,4 @@
 import { shuffle, hasGossipProtocol } from './utils'
-import { PeerStreams } from './peerStreams'
 import Gossipsub = require('./index')
 
 /**
@@ -10,15 +9,15 @@ import Gossipsub = require('./index')
  * @param {String} topic
  * @param {Number} count
  * @param {Function} [filter] a function to filter acceptable peers
- * @returns {Set<Peer>}
+ * @returns {Set<string>}
  *
  */
 export function getGossipPeers (
   router: Gossipsub,
   topic: string,
   count: number,
-  filter: (peerStreams: PeerStreams) => boolean = () => true
-): Set<PeerStreams> {
+  filter: (id: string) => boolean = () => true
+): Set<string> {
   const peersInTopic = router.topics.get(topic)
   if (!peersInTopic) {
     return new Set()
@@ -26,7 +25,7 @@ export function getGossipPeers (
 
   // Adds all peers using our protocol
   // that also pass the filter function
-  let peers: PeerStreams[] = []
+  let peers: string[] = []
   peersInTopic.forEach((id) => {
     const peerStreams = router.peers.get(id)
     if (!peerStreams) {
@@ -34,9 +33,9 @@ export function getGossipPeers (
     }
     if (
       hasGossipProtocol(peerStreams.protocol) &&
-      filter(peerStreams)
+      filter(id)
     ) {
-      peers.push(peerStreams)
+      peers.push(id)
     }
   })
 

--- a/ts/pubsub.js
+++ b/ts/pubsub.js
@@ -80,13 +80,10 @@ class BasicPubSub extends Pubsub {
    */
   async _onPeerConnected (peerId, conn) {
     await super._onPeerConnected(peerId, conn)
-    const idB58Str = peerId.toB58String()
-    const peerStreams = this.peers.get(idB58Str)
+    const id = peerId.toB58String()
 
-    if (peerStreams && peerStreams.isWritable) {
-      // Immediately send my own subscriptions to the newly established conn
-      this._sendSubscriptions(peerStreams, Array.from(this.subscriptions), true)
-    }
+    // Immediately send my own subscriptions to the newly established conn
+    this._sendSubscriptions(id, Array.from(this.subscriptions), true)
   }
 
   /**
@@ -312,7 +309,7 @@ class BasicPubSub extends Pubsub {
     })
 
     // Broadcast SUBSCRIBE to all peers
-    this.peers.forEach((peer) => this._sendSubscriptions(peer, topics, true))
+    this.peers.forEach((_, id) => this._sendSubscriptions(id, topics, true))
   }
 
   /**
@@ -348,7 +345,7 @@ class BasicPubSub extends Pubsub {
     })
 
     // Broadcast UNSUBSCRIBE to all peers ready
-    this.peers.forEach((peer) => this._sendSubscriptions(peer, topics, false))
+    this.peers.forEach((_, id) => this._sendSubscriptions(id, topics, false))
   }
 
   /**
@@ -417,11 +414,12 @@ class BasicPubSub extends Pubsub {
 
   /**
    * Send an rpc object to a peer
-   * @param {PeerStreams} peerStreams
+   * @param {string} id peer id
    * @param {RPC} rpc
    * @returns {void}
    */
-  _sendRpc (peerStreams, rpc) {
+  _sendRpc (id, rpc) {
+    const peerStreams = this.peers.get(id)
     if (!peerStreams || !peerStreams.isWritable) {
       return
     }
@@ -430,13 +428,13 @@ class BasicPubSub extends Pubsub {
 
   /**
    * Send subscroptions to a peer
-   * @param {PeerStreams} peerStreams
+   * @param {string} id peer id
    * @param {string[]} topics
    * @param {boolean} subscribe set to false for unsubscriptions
    * @returns {void}
    */
-  _sendSubscriptions (peerStreams, topics, subscribe) {
-    return this._sendRpc(peerStreams, {
+  _sendSubscriptions (id, topics, subscribe) {
+    return this._sendRpc(id, {
       subscriptions: topics.map(t => ({ topicID: t, subscribe: subscribe }))
     })
   }


### PR DESCRIPTION
Replace many uses of `PeerStreams` with `string` peer id as the primary/sole peer identifier
- internal maps, use string peer id where possible
- internal methods, use string peer id where possible
- only use `peerStreams` when the `peerStreams.protocol` or `peerStreams.write` is needed.

In all cases, the variable name `id` is used to refer to a string peer id.
In a separate PR, we might consider renaming this variable to `p` to more closely conform to the go-libp2p-pubsub implementation.