### PR TITLE
chore: use libp2p@0.29 branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "it-pair": "^1.0.0",
-    "libp2p": "https://github.com/libp2p/js-libp2p#feat/certified-addressbook",
+    "libp2p": "https://github.com/libp2p/js-libp2p#0.29.x",
     "libp2p-floodsub": "https://github.com/chainsafe/js-libp2p-floodsub#chore/update-pubsub",
     "libp2p-mplex": "^0.9.5",
     "libp2p-noise": "^1.1.2",
@@ -82,7 +82,7 @@
     "typescript": "^3.9.3"
   },
   "peerDependencies": {
-    "libp2p": "https://github.com/libp2p/js-libp2p#feat/certified-addressbook"
+    "libp2p": "https://github.com/libp2p/js-libp2p#0.29.x"
   },
   "contributors": [
     "Cayman <caymannava@gmail.com>",


### PR DESCRIPTION
Certified AddressBook got merged. Updated the dependency as the branch is being deleted