### PR TITLE
gs1.1: chore: add go gossipsub tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "lodash": "^4.17.15",
     "mocha": "^7.1.1",
     "multiaddr": "^8.0.0",
+    "p-retry": "^4.2.0",
     "p-times": "^2.1.0",
     "p-wait-for": "^3.1.0",
     "promisify-es6": "^1.0.3",

--- a/test/go-gossipsub.js
+++ b/test/go-gossipsub.js
@@ -772,7 +772,7 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
     psubs.forEach(ps => ps.subscribe(topic))
 
     // wait a bit for the mesh to build
-    await Promise.all(psubs.map(ps => awaitEvents(ps, 'gossipsub:heartbeat', 15, 20000)))
+    await Promise.all(psubs.map(ps => awaitEvents(ps, 'gossipsub:heartbeat', 15, 25000)))
 
     // check that all peers have > 1 connection
     psubs.forEach(ps => {

--- a/test/go-gossipsub.js
+++ b/test/go-gossipsub.js
@@ -1126,7 +1126,7 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
     const realPeerIds = real.map(r => r.peerId.toB58String())
     const sybilPeerIds = sybils.map(r => r.peerId.toB58String())
 
-    await pRetry(() => {
+    await pRetry(() => new Promise((resolve, reject) => {
       real.forEach(async (r, i) => {
         const meshPeers = r.mesh.get(topic)
         let count = 0
@@ -1138,9 +1138,10 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
 
         if (count < 3) {
           await delay(100)
-          throw new Error()
+          reject()
         }
+        resolve()
       })
-    }, { retries: 10 })
+    }), { retries: 10 })
   })
 })

--- a/test/go-gossipsub.js
+++ b/test/go-gossipsub.js
@@ -40,7 +40,7 @@ const checkReceivedMessage = (topic, data, senderIx, msgIx) =>
     const t = setTimeout(() => {
       psub.off(topic, cb)
       reject(new Error(`Message never received, sender ${senderIx}, receiver ${receiverIx}, index ${msgIx}`))
-    }, 10000)
+    }, 20000)
     cb = (msg) => {
       if (data.equals(msg.data)) {
         clearTimeout(t)
@@ -1127,7 +1127,7 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
     const sybilPeerIds = sybils.map(r => r.peerId.toB58String())
 
     await pRetry(() => {
-      real.forEach((r, i) => {
+      real.forEach(async (r, i) => {
         const meshPeers = r.mesh.get(topic)
         let count = 0
         realPeerIds.forEach(p => {
@@ -1137,6 +1137,7 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
         })
 
         if (count < 3) {
+          await delay(100)
           throw new Error()
         }
       })

--- a/test/go-gossipsub.spec.js
+++ b/test/go-gossipsub.spec.js
@@ -53,7 +53,7 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     // Subscribe to the topic, all nodes
     // Sparsely connect the nodes
     // Publish 100 messages, each from a random node
-    // Assert that the 99 other nodes receive the message
+    // Assert that subscribed nodes receive the message
     const psubs = await createGossipsubs({
       number: 20,
       options: { scoreParams: { IPColocationFactorThreshold: 20 } }
@@ -84,7 +84,7 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     // Subscribe to the topic, all nodes
     // Densely connect the nodes
     // Publish 100 messages, each from a random node
-    // Assert that the 99 other nodes receive the message
+    // Assert that subscribed nodes receive the message
     const psubs = await createGossipsubs({
       number: 20,
       options: { scoreParams: { IPColocationFactorThreshold: 20 } }
@@ -115,10 +115,10 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     // Subscribe to the topic, all nodes except the first
     // Densely connect the nodes
     // Publish 100 messages, each from the first node
-    // Assert that the 99 other nodes receive the message
+    // Assert that subscribed nodes receive the message
     // Subscribe to the topic, first node
     // Publish 100 messages, each from the first node
-    // Assert that the 99 other nodes receive the message
+    // Assert that subscribed nodes receive the message
     const psubs = await createGossipsubs({
       number: 20,
       options: { scoreParams: { IPColocationFactorThreshold: 20 } }
@@ -172,7 +172,7 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     // Subscribe to the topic, all nodes except the first
     // Densely connect the nodes
     // Publish 100 messages, each from the first node
-    // Assert that the 99 other nodes receive the message
+    // Assert that subscribed nodes receive the message
     // Unsubscribe to the topic, all nodes except the first
     // Resubscribe to the topic, all nodes except the first
     // Publish 100 messages, each from the first node

--- a/test/go-gossipsub.spec.js
+++ b/test/go-gossipsub.spec.js
@@ -33,6 +33,7 @@ const {
 const checkReceivedMessage = (topic, data, senderIx, msgIx) =>
   (psub, receiverIx) => new Promise((resolve, reject) => {
     const t = setTimeout(() => {
+      psub.removeAllListeners()
       expect.fail(`Message never received, sender ${senderIx}, receiver ${receiverIx}, index ${msgIx}`)
       reject()
     }, 10000)

--- a/test/go-gossipsub.spec.js
+++ b/test/go-gossipsub.spec.js
@@ -43,12 +43,12 @@ const checkReceivedMessage = (topic, data, senderIx, msgIx) =>
     })
   })
 
-describe("go-libp2p-pubsub gossipsub tests", () => {
+describe("go-libp2p-pubsub gossipsub tests", function () {
+  this.timeout(100000)
   afterEach(() => {
     sinon.restore()
   })
   it("test sparse gossipsub", async function () {
-    this.timeout(100000)
     // Create 20 gossipsub nodes
     // Subscribe to the topic, all nodes
     // Sparsely connect the nodes
@@ -79,7 +79,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test dense gossipsub", async function () {
-    this.timeout(100000)
     // Create 20 gossipsub nodes
     // Subscribe to the topic, all nodes
     // Densely connect the nodes
@@ -110,7 +109,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test gossipsub fanout", async function () {
-    this.timeout(100000)
     // Create 20 gossipsub nodes
     // Subscribe to the topic, all nodes except the first
     // Densely connect the nodes
@@ -167,7 +165,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test gossipsub fanout maintenance", async function () {
-    this.timeout(100000)
     // Create 20 gossipsub nodes
     // Subscribe to the topic, all nodes except the first
     // Densely connect the nodes
@@ -230,7 +227,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test gossipsub fanout expiry", async function () {
-    this.timeout(100000)
     // Create 10 gossipsub nodes
     // Subscribe to the topic, all nodes except the first
     // Densely connect the nodes
@@ -277,7 +273,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     expect(psubs[0].fanout.size).to.be.eql(0)
   })
   it("test gossipsub gossip", async function () {
-    this.timeout(100000)
     // Create 20 gossipsub nodes
     // Subscribe to the topic, all nodes
     // Densely connect the nodes
@@ -313,7 +308,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     await delay(2000)
   })
   it("test gossipsub gossip propagation", async function () {
-    this.timeout(100000)
     // Create 20 gossipsub nodes
     // Split into two groups, only a single node shared between
     // Densely connect each group to itself
@@ -374,7 +368,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test gossipsub prune", async function () {
-    this.timeout(100000)
     // Create 20 gossipsub nodes
     // Subscribe to the topic, all nodes
     // Densely connect nodes
@@ -413,7 +406,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test gossipsub graft", async function () {
-    this.timeout(100000)
     // Create 20 gossipsub nodes
     // Sparsely connect nodes
     // Subscribe to the topic, all nodes, waiting for each subscription to propagate first
@@ -448,7 +440,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test gossipsub remove peer", async function () {
-    this.timeout(100000)
     // Create 20 gossipsub nodes
     // Subscribe to the topic, all nodes
     // Densely connect nodes
@@ -487,7 +478,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test gossipsub graft prune retry", async function () {
-    this.timeout(100000)
     // Create 10 gossipsub nodes
     // Densely connect nodes
     // Subscribe to 35 topics, all nodes
@@ -522,7 +512,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test gossipsub control piggyback", async function () {
-    this.timeout(100000)
     // Create 10 gossipsub nodes
     // Densely connect nodes
     // Subscribe to a 'flood' topic, all nodes
@@ -582,7 +571,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test mixed gossipsub", async function () {
-    this.timeout(100000)
     // Create 20 gossipsub nodes
     // Create 10 floodsub nodes
     // Subscribe to the topic, all nodes
@@ -627,7 +615,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test gossipsub multihops", async function () {
-    this.timeout(100000)
     // Create 6 gossipsub nodes
     // Connect nodes in a line (eg: 0 -> 1 -> 2 -> 3 ...)
     // Subscribe to the topic, all nodes
@@ -655,7 +642,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     await results
   })
   it("test gossipsub tree topology", async function () {
-    this.timeout(100000)
     // Create 10 gossipsub nodes
     // Connect nodes in a tree, diagram below
     // Subscribe to the topic, all nodes
@@ -709,7 +695,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test gossipsub star topology with signed peer records", async function () {
-    this.timeout(100000)
     // Create 20 gossipsub nodes with lower degrees
     // Connect nodes to a center node, with the center having very low degree
     // Subscribe to the topic, all nodes
@@ -764,7 +749,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test gossipsub direct peers", async function () {
-    this.timeout(100000)
     // Create 3 gossipsub nodes
     // 2 and 3 with direct peer connections with each other
     // Connect nodes: 2 <- 1 -> 3
@@ -850,7 +834,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test gossipsub flood publish", async function () {
-    this.timeout(100000)
     // Create 30 gossipsub nodes
     // Connect in star topology
     // Subscribe to the topic, all nodes
@@ -885,7 +868,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     }
   })
   it("test gossipsub negative score", async function () {
-    this.timeout(100000)
     // Create 20 gossipsub nodes, with scoring params to quickly lower node 0's score
     // Connect densely
     // Subscribe to the topic, all nodes
@@ -932,7 +914,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     await delay(2000)
   })
   it("test gossipsub score validator ex", async function () {
-    this.timeout(100000)
     // Create 3 gossipsub nodes
     // Connect fully
     // Register a topic validator on node 0: ignore 1, reject 2
@@ -984,7 +965,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     expect(psubs[0].score.score(psubs[2].peerId.toB58String())).to.be.lt(0)
   })
   it("test gossipsub piggyback control", async function () {
-    this.timeout(100000)
     const libp2ps = await createPeers({ number: 2 })
     const otherId = libp2ps[1].peerId.toB58String()
     const psub = new Gossipsub(libp2ps[0])
@@ -1018,7 +998,6 @@ describe("go-libp2p-pubsub gossipsub tests", () => {
     expect(rpc.control.prune[1].topicID).to.be.eql(test3)
   })
   it("test gossipsub opportunistic grafting", async function () {
-    this.timeout(100000)
     // Create 50 nodes
     // 10 real gossip nodes, 40 'sybil' nodes, unresponsive nodes
     // Connect some of the real nodes

--- a/test/go-gossipsub.spec.js
+++ b/test/go-gossipsub.spec.js
@@ -626,9 +626,7 @@ describe.only("go-libp2p-pubsub gossipsub tests", function () {
       )
     })
     const fsubs = libp2ps.slice(20).map((libp2p) => {
-      const fs = new Floodsub(
-        libp2p.peerId, libp2p.registrar
-      )
+      const fs = new Floodsub(libp2p)
       fs._libp2p = libp2p
       return fs
     })

--- a/test/go-gossipsub.spec.js
+++ b/test/go-gossipsub.spec.js
@@ -1,0 +1,1115 @@
+/**
+ * These tests were translated from:
+ *   https://github.com/libp2p/go-libp2p-pubsub/blob/master/gossipsub_test.go
+ */
+const { expect } = require('chai')
+const delay = require('delay')
+const PeerId = require('peer-id')
+const errcode = require('err-code')
+const sinon = require('sinon')
+
+const Floodsub = require('libp2p-floodsub')
+const Gossipsub = require('../src')
+const constants = require('../src/constants')
+const { GossipsubD } = require('../src/constants')
+const {
+  createGossipsubs,
+  sparseConnect,
+  denseConnect,
+  stopNode,
+  startNode,
+  createPeers,
+  expectSet,
+  connectSome,
+  connectGossipsub
+} = require('./utils')
+
+/**
+ * Given a topic and data (and debug metadata -- sender index and msg index)
+ * Return a function (takes a gossipsub (and receiver index))
+ * that returns a Promise that awaits the message being received
+ * and checks that the received message equals the given message
+ */
+const checkReceivedMessage = (topic, data, senderIx, msgIx) =>
+  (psub, receiverIx) => new Promise((resolve, reject) => {
+    const t = setTimeout(() => {
+      expect.fail(`Message never received, sender ${senderIx}, receiver ${receiverIx}, index ${msgIx}`)
+      reject()
+    }, 10000)
+    psub.once(topic, (msg) => {
+      clearTimeout(t)
+      expect(data).to.deep.equal(msg.data)
+      resolve()
+    })
+  })
+
+describe.skip("go-libp2p-pubsub gossipsub tests", () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+  it("test sparse gossipsub", async function () {
+    this.timeout(100000)
+    // Create 20 gossipsub nodes
+    // Subscribe to the topic, all nodes
+    // Sparsely connect the nodes
+    // Publish 100 messages, each from a random node
+    // Assert that the 99 other nodes receive the message
+    const psubs = await createGossipsubs({
+      number: 20,
+      options: { scoreParams: { IPColocationFactorThreshold: 20 } }
+    })
+    const topic = 'foobar'
+    psubs.forEach(ps => ps.subscribe(topic))
+
+    await sparseConnect(psubs)
+
+    // wait for heartbeats to build mesh
+    await delay(2000)
+
+    for (let i = 0; i < 100; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = Math.floor(Math.random() * psubs.length)
+      const results = Promise.all(
+        psubs
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+  })
+  it("test dense gossipsub", async function () {
+    this.timeout(100000)
+    // Create 20 gossipsub nodes
+    // Subscribe to the topic, all nodes
+    // Densely connect the nodes
+    // Publish 100 messages, each from a random node
+    // Assert that the 99 other nodes receive the message
+    const psubs = await createGossipsubs({
+      number: 20,
+      options: { scoreParams: { IPColocationFactorThreshold: 20 } }
+    })
+    const topic = 'foobar'
+    psubs.forEach(ps => ps.subscribe(topic))
+
+    await denseConnect(psubs)
+
+    // wait for heartbeats to build mesh
+    await delay(2000)
+
+    for (let i = 0; i < 100; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = Math.floor(Math.random() * psubs.length)
+      const results = Promise.all(
+        psubs
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+  })
+  it("test gossipsub fanout", async function () {
+    this.timeout(100000)
+    // Create 20 gossipsub nodes
+    // Subscribe to the topic, all nodes except the first
+    // Densely connect the nodes
+    // Publish 100 messages, each from the first node
+    // Assert that the 99 other nodes receive the message
+    // Subscribe to the topic, first node
+    // Publish 100 messages, each from the first node
+    // Assert that the 99 other nodes receive the message
+    const psubs = await createGossipsubs({
+      number: 20,
+      options: { scoreParams: { IPColocationFactorThreshold: 20 } }
+    })
+    const topic = 'foobar'
+    psubs.slice(1).forEach(ps => ps.subscribe(topic))
+
+    await denseConnect(psubs)
+
+    // wait for heartbeats to build mesh
+    await delay(2000)
+
+    for (let i = 0; i < 100; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+
+      const owner = 0
+
+      const results = Promise.all(
+        psubs
+          .slice(1)
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+
+    psubs[0].subscribe(topic)
+
+    // wait for a heartbeat
+    await delay(1000)
+
+    for (let i = 0; i < 100; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+
+      const owner = 0
+
+      const results = Promise.all(
+        psubs
+          .slice(1)
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+  })
+  it("test gossipsub fanout maintenance", async function () {
+    this.timeout(100000)
+    // Create 20 gossipsub nodes
+    // Subscribe to the topic, all nodes except the first
+    // Densely connect the nodes
+    // Publish 100 messages, each from the first node
+    // Assert that the 99 other nodes receive the message
+    // Unsubscribe to the topic, all nodes except the first
+    // Resubscribe to the topic, all nodes except the first
+    // Publish 100 messages, each from the first node
+    // Assert that the subscribed nodes receive the message
+    const psubs = await createGossipsubs({
+      number: 20,
+      options: { scoreParams: { IPColocationFactorThreshold: 20 } }
+    })
+    const topic = 'foobar'
+    psubs.slice(1).forEach(ps => ps.subscribe(topic))
+
+    await denseConnect(psubs)
+
+    // wait for heartbeats to build mesh
+    await delay(2000)
+
+    for (let i = 0; i < 100; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+
+      const owner = 0
+
+      const results = Promise.all(
+        psubs
+          .slice(1)
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+
+    psubs.slice(1).forEach(ps => ps.unsubscribe(topic))
+
+    // wait for heartbeats
+    await delay(2000)
+
+    psubs.slice(1).forEach(ps => ps.subscribe(topic))
+
+    // wait for heartbeats
+    await delay(2000)
+
+    for (let i = 0; i < 100; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+
+      const owner = 0
+
+      const results = Promise.all(
+        psubs
+          .slice(1)
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+  })
+  it("test gossipsub fanout expiry", async function () {
+    this.timeout(100000)
+    // Create 10 gossipsub nodes
+    // Subscribe to the topic, all nodes except the first
+    // Densely connect the nodes
+    // Publish 5 messages, each from the first node
+    // Assert that the subscribed nodes receive every message
+    // Assert that the first node has fanout peers
+    // Wait until fanout expiry
+    // Assert that the first node has no fanout
+    sinon.replace(constants, 'GossipsubFanoutTTL', 1000)
+    const psubs = await createGossipsubs({
+      number: 10,
+      options: {
+        scoreParams: { IPColocationFactorThreshold: 20 },
+        floodPublish: false
+      }
+    })
+    const topic = 'foobar'
+    psubs.slice(1).forEach(ps => ps.subscribe(topic))
+
+    await denseConnect(psubs)
+
+    // wait for heartbeats to build mesh
+    await delay(2000)
+
+    for (let i = 0; i < 5; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+
+      const owner = 0
+
+      const results = Promise.all(
+        psubs
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+
+    expect(psubs[0].fanout.size).to.be.gt(0)
+
+    // wait for TTL to expore fanout peers in owner
+    await delay(2000)
+
+    expect(psubs[0].fanout.size).to.be.eql(0)
+  })
+  it("test gossipsub gossip", async function () {
+    this.timeout(100000)
+    // Create 20 gossipsub nodes
+    // Subscribe to the topic, all nodes
+    // Densely connect the nodes
+    // Publish 100 messages, each from a random node
+    // Assert that the subscribed nodes receive the message
+    // Wait a bit between each message so gossip can be interleaved
+    const psubs = await createGossipsubs({
+      number: 20,
+      options: { scoreParams: { IPColocationFactorThreshold: 20 } }
+    })
+    const topic = 'foobar'
+    psubs.forEach(ps => ps.subscribe(topic))
+
+    await denseConnect(psubs)
+
+    // wait for heartbeats to build mesh
+    await delay(2000)
+
+    for (let i = 0; i < 100; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = Math.floor(Math.random() * psubs.length)
+      const results = Promise.all(
+        psubs
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+      // wait a bit to have some gossip interleaved
+      await delay(100)
+    }
+    // and wait for some gossip flushing
+    await delay(2000)
+  })
+  it.skip("test gossipsub gossip propagation", async function () {
+    this.timeout(100000)
+    // Create 20 gossipsub nodes
+    // Split into two groups, only a single node shared between
+    // Densely connect each group to itself
+    // Subscribe to the topic, first group minus the shared node
+    // Publish 10 messages, each from the shared node
+    // Assert that the first group receives the messages
+    // Subscribe to the topic, second group minus the shared node
+    // Assert that the second group receives the messages (via gossip)
+    const psubs = await createGossipsubs({
+      number: 20,
+      options: { scoreParams: { IPColocationFactorThreshold: 20 } }
+    })
+    const topic = 'foobar'
+    const group1 = psubs.slice(0, GossipsubD + 1)
+    const group2 = psubs.slice(GossipsubD + 1)
+    group2.push(psubs[0])
+
+    await denseConnect(group1)
+    await denseConnect(group2)
+
+    group1.slice(1).forEach(ps => ps.subscribe(topic))
+
+    // wait for heartbeats to build mesh
+    await delay(2000)
+
+    for (let i = 0; i < 10; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = 0
+      const results = Promise.all(
+        group1.slice(1)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+
+    await delay(100)
+
+    psubs.slice(GossipsubD+1).forEach(ps => ps.subscribe(topic))
+
+    const received = Array.from({ length: psubs.length - (GossipsubD + 1) }, () => ([]))
+    const results = Promise.all(
+      psubs.slice(GossipsubD+1).map((ps, ix) => {
+        const t = setTimeout(reject, 10000)
+        ps.on(topic, (m) => {
+          received[ix].push(m)
+          if (received[ix].length >= 10) {
+            clearTimeout(t)
+            resolve()
+          }
+        })
+      })
+    )
+    try {
+      await results
+    } catch (e) {
+      expect.fail(e)
+    }
+  })
+  it("test gossipsub prune", async function () {
+    this.timeout(100000)
+    // Create 20 gossipsub nodes
+    // Subscribe to the topic, all nodes
+    // Densely connect nodes
+    // Unsubscribe to the topic, first 5 nodes
+    // Publish 100 messages, each from a random node
+    // Assert that the subscribed nodes receive every message
+    const psubs = await createGossipsubs({
+      number: 20,
+      options: { scoreParams: { IPColocationFactorThreshold: 20 } }
+    })
+    const topic = 'foobar'
+    psubs.forEach(ps => ps.subscribe(topic))
+
+    await denseConnect(psubs)
+
+    // wait for heartbeats to build mesh
+    await delay(2000)
+
+    // disconnect some peers from the mesh to get some PRUNEs
+    psubs.slice(0, 5).forEach(ps => ps.unsubscribe(topic))
+
+    // wait a bit to take effect
+    await delay(100)
+
+    for (let i = 0; i < 100; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = Math.floor(Math.random() * psubs.length)
+      const results = Promise.all(
+        psubs
+          .slice(5)
+          .filter((psub, j) => j+5 !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+  })
+  it("test gossipsub graft", async function () {
+    this.timeout(100000)
+    // Create 20 gossipsub nodes
+    // Sparsely connect nodes
+    // Subscribe to the topic, all nodes, waiting for each subscription to propagate first
+    // Publish 100 messages, each from a random node
+    // Assert that the subscribed nodes receive every message
+    const psubs = await createGossipsubs({
+      number: 20,
+      options: { scoreParams: { IPColocationFactorThreshold: 20 } }
+    })
+    const topic = 'foobar'
+
+    await sparseConnect(psubs)
+
+    psubs.forEach(async ps => {
+      ps.subscribe(topic)
+      // wait for announce to propagate
+      await delay(100)
+    })
+
+    await delay(1000)
+
+    for (let i = 0; i < 100; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = Math.floor(Math.random() * psubs.length)
+      const results = Promise.all(
+        psubs
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+  })
+  it("test gossipsub remove peer", async function () {
+    this.timeout(100000)
+    // Create 20 gossipsub nodes
+    // Subscribe to the topic, all nodes
+    // Densely connect nodes
+    // Stop 5 nodes
+    // Publish 100 messages, each from a random still-started node
+    // Assert that the subscribed nodes receive every message
+    const psubs = await createGossipsubs({
+      number: 20,
+      options: { scoreParams: { IPColocationFactorThreshold: 20 } }
+    })
+    const topic = 'foobar'
+
+    await denseConnect(psubs)
+
+    psubs.forEach(async ps => ps.subscribe(topic))
+
+    // wait for heartbeats to build mesh
+    await delay(2000)
+
+    // disconnect some peers to exercise _removePeer paths
+    await Promise.all(psubs.slice(0, 5).map(ps => stopNode(ps)))
+
+    // wait a heartbeat
+    await delay(1000)
+
+    for (let i = 0; i < 100; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = Math.floor(Math.random() * (psubs.length - 5))
+      const results = Promise.all(
+        psubs.slice(5)
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs.slice(5)[owner].publish(topic, msg)
+      await results
+    }
+  })
+  it("test gossipsub graft prune retry", async function () {
+    this.timeout(100000)
+    // Create 10 gossipsub nodes
+    // Densely connect nodes
+    // Subscribe to 35 topics, all nodes
+    // Publish a message from each topic, each from a random node
+    // Assert that the subscribed nodes receive every message
+    const psubs = await createGossipsubs({
+      number: 10,
+      options: { scoreParams: { IPColocationFactorThreshold: 20 } }
+    })
+    const topic = 'foobar'
+
+    await denseConnect(psubs)
+
+    for (let i = 0; i < 35; i++) {
+      psubs.forEach(async ps => ps.subscribe(topic+i))
+    }
+
+    // wait for heartbeats to build mesh
+    await delay(9000)
+
+    for (let i = 0; i < 35; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = Math.floor(Math.random() * psubs.length)
+      const results = Promise.all(
+        psubs
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic+i, msg, owner, i))
+      )
+      await psubs[owner].publish(topic+i, msg)
+      await delay(20)
+      await results
+    }
+  })
+  it.skip("test gossipsub control piggyback", async function () {
+    this.timeout(100000)
+    // Create 10 gossipsub nodes
+    // Densely connect nodes
+    // Subscribe to a 'flood' topic, all nodes
+    // Publish 10k messages on the flood topic, each from a random node, in the background
+    // Subscribe to 5 topics, all nodes
+    // Wait for the flood to stop
+    // Publish a message to each topic, each from a random node
+    // Assert that subscribed nodes receive each message
+    // Publish a message from each topic, each from a random node
+    // Assert that the subscribed nodes receive every message
+    const psubs = await createGossipsubs({
+      number: 10,
+      options: { scoreParams: { IPColocationFactorThreshold: 20 } }
+    })
+    const topic = 'foobar'
+
+    await denseConnect(psubs)
+
+    const floodTopic = 'flood'
+    psubs.forEach(ps => ps.subscribe(floodTopic))
+
+    await delay(1000)
+
+    // create a background flood of messages that overloads the queues
+    const floodOwner = Math.floor(Math.random() * psubs.length)
+    const floodMsg = Buffer.from('background flooooood')
+    const backgroundFlood = new Promise(async resolve => {
+      for (let i = 0; i < 10000; i++) {
+        await psubs[floodOwner].publish(floodTopic, floodMsg)
+      }
+      resolve()
+    })
+
+    await delay(20)
+
+    // and subscribe to a bunch of topics in the meantime -- this should
+    // result in some dropped control messages, with subsequent piggybacking
+    // in the background flood
+    for (let i = 0; i < 5; i++) {
+      psubs.forEach(ps => ps.subscribe(topic+i))
+    }
+
+    // wait for the flood to stop
+    await backgroundFlood
+
+    // and test that we have functional overlays
+    for (let i = 0; i < 5; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = Math.floor(Math.random() * psubs.length)
+      const results = Promise.all(
+        psubs
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic+i, msg, owner, i))
+      )
+      await psubs[owner].publish(topic+i, msg)
+      await results
+    }
+  })
+  it("test mixed gossipsub", async function () {
+    this.timeout(100000)
+    // Create 20 gossipsub nodes
+    // Create 10 floodsub nodes
+    // Subscribe to the topic, all nodes
+    // Sparsely connect nodes
+    // Publish 100 messages, each from a random node
+    // Assert that the subscribed nodes receive every message
+    const libp2ps = await createPeers({ number: 30 })
+    const gsubs = libp2ps.slice(0, 20).map((libp2p) => {
+      return new Gossipsub(
+        libp2p,
+        { scoreParams: { IPColocationFactorThreshold: 20 } }
+      )
+    })
+    const fsubs = libp2ps.slice(20).map((libp2p) => {
+      const fs = new Floodsub(
+        libp2p.peerId, libp2p.registrar
+      )
+      fs._libp2p = libp2p
+      return fs
+    })
+    const psubs = gsubs.concat(fsubs)
+    await Promise.all(psubs.map(ps => ps.start()))
+
+    const topic = 'foobar'
+    psubs.forEach(ps => ps.subscribe(topic))
+
+    await sparseConnect(psubs)
+
+    // wait for heartbeats to build mesh
+    await delay(2000)
+
+    for (let i = 0; i < 100; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = Math.floor(Math.random() * psubs.length)
+      const results = Promise.all(
+        psubs
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+  })
+  it("test gossipsub multihops", async function () {
+    this.timeout(100000)
+    // Create 6 gossipsub nodes
+    // Connect nodes in a line (eg: 0 -> 1 -> 2 -> 3 ...)
+    // Subscribe to the topic, all nodes
+    // Publish a message from node 0
+    // Assert that the last node receives the message
+    const psubs = await createGossipsubs({
+      number: 6,
+      options: { scoreParams: { IPColocationFactorThreshold: 20 } }
+    })
+    const topic = 'foobar'
+
+    for (let i = 0; i < 5; i++) {
+      await psubs[i]._libp2p.dialProtocol(psubs[i+1]._libp2p.peerId, psubs[i].multicodecs)
+    }
+
+    psubs.forEach(ps => ps.subscribe(topic))
+
+    // wait for heartbeats to build mesh
+    await delay(2000)
+
+    const msg = Buffer.from(`${0} its not a flooooood ${0}`)
+    const owner = 0
+    const results = checkReceivedMessage(topic, msg, owner, 0)(psubs[5], 5)
+    await psubs[owner].publish(topic, msg)
+    await results
+  })
+  it("test gossipsub tree topology", async function () {
+    this.timeout(100000)
+    // Create 10 gossipsub nodes
+    // Connect nodes in a tree, diagram below
+    // Subscribe to the topic, all nodes
+    // Assert that the nodes are peered appropriately
+    // Publish two messages, one from either end of the tree
+    // Assert that the subscribed nodes receive every message
+    const psubs = await createGossipsubs({
+      number: 10,
+      options: { scoreParams: { IPColocationFactorThreshold: 20 } }
+    })
+    const topic = 'foobar'
+
+    /*
+     [0] -> [1] -> [2] -> [3]
+      |      L->[4]
+      v
+     [5] -> [6] -> [7]
+      |
+      v
+     [8] -> [9]
+    */
+    const multicodecs = psubs[0].multicodecs
+    await psubs[0]._libp2p.dialProtocol(psubs[1]._libp2p.peerId, multicodecs)
+    await psubs[1]._libp2p.dialProtocol(psubs[2]._libp2p.peerId, multicodecs)
+    await psubs[1]._libp2p.dialProtocol(psubs[4]._libp2p.peerId, multicodecs)
+    await psubs[2]._libp2p.dialProtocol(psubs[3]._libp2p.peerId, multicodecs)
+    await psubs[0]._libp2p.dialProtocol(psubs[5]._libp2p.peerId, multicodecs)
+    await psubs[5]._libp2p.dialProtocol(psubs[6]._libp2p.peerId, multicodecs)
+    await psubs[5]._libp2p.dialProtocol(psubs[8]._libp2p.peerId, multicodecs)
+    await psubs[6]._libp2p.dialProtocol(psubs[7]._libp2p.peerId, multicodecs)
+    await psubs[8]._libp2p.dialProtocol(psubs[9]._libp2p.peerId, multicodecs)
+
+    psubs.forEach(ps => ps.subscribe(topic))
+
+    // wait for heartbeats to build mesh
+    await delay(2000)
+
+    expectSet(new Set(psubs[0].peers.keys()), [psubs[1].peerId.toB58String(), psubs[5].peerId.toB58String()])
+    expectSet(new Set(psubs[1].peers.keys()), [psubs[0].peerId.toB58String(), psubs[2].peerId.toB58String(), psubs[4].peerId.toB58String()])
+    expectSet(new Set(psubs[2].peers.keys()), [psubs[1].peerId.toB58String(), psubs[3].peerId.toB58String()])
+
+    for (const owner of [9, 3]) {
+      const msg = Buffer.from(`${owner} its not a flooooood ${owner}`)
+      const results = Promise.all(
+        psubs
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, owner))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+  })
+  it("test gossipsub star topology with signed peer records", async function () {
+    this.timeout(100000)
+    // Create 20 gossipsub nodes with lower degrees
+    // Connect nodes to a center node, with the center having very low degree
+    // Subscribe to the topic, all nodes
+    // Assert that all nodes have > 1 connection
+    // Publish one message per node
+    // Assert that the subscribed nodes receive every message
+    const psubs = await createGossipsubs({
+      number: 20,
+      options: {
+        scoreThresholds: { acceptPXThreshold: 0 },
+        scoreParams: { IPColocationFactorThreshold: 20 },
+        doPX: true,
+        D: 4, Dhi: 5, Dlo: 3, Dscore: 3
+      }
+    })
+
+    // configure the center of the star with very low D
+    psubs[0].D = 0
+    psubs[0].Dhi = 0
+    psubs[0].Dlo = 0
+    psubs[0].Dscore = 0
+
+    // build the star
+    await psubs.slice(1).map(ps => psubs[0]._libp2p.dialProtocol(ps._libp2p.peerId, ps.multicodecs))
+
+
+    await delay(2000)
+
+    // build the mesh
+    const topic = 'foobar'
+    psubs.forEach(ps => ps.subscribe(topic))
+
+    // wait a bit for the mesh to build
+    await delay(15 * 1000)
+
+    // check that all peers have > 1 connection
+    psubs.forEach(ps => {
+      expect(ps._libp2p.connectionManager.size).to.be.gt(1)
+    })
+
+    // send a message from each peer and assert it was propagated
+    for (let i = 0; i < psubs.length; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = i
+      const results = Promise.all(
+        psubs
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+  })
+  it("test gossipsub direct peers", async function () {
+    this.timeout(100000)
+    // Create 3 gossipsub nodes
+    // 2 and 3 with direct peer connections with each other
+    // Connect nodes: 2 <- 1 -> 3
+    // Assert that the nodes are connected
+    // Subscribe to the topic, all nodes
+    // Publish a message from each node
+    // Assert that all nodes receive the messages
+    // Disconnect peers
+    // Assert peers reconnect
+    // Publish a message from each node
+    // Assert that all nodes receive the messages
+    sinon.replace(constants, 'GossipsubDirectConnectTicks', 2)
+    const libp2ps = await createPeers({ number: 3 })
+    const psubs =  [
+      new Gossipsub(
+        libp2ps[0],
+        { scoreParams: { IPColocationFactorThreshold: 20 } }
+      ),
+      new Gossipsub(
+        libp2ps[1],
+        {
+          scoreParams: { IPColocationFactorThreshold: 20 },
+          directPeers: [{
+            id: libp2ps[2].peerId,
+            addrs: libp2ps[2].multiaddrs
+          }]
+        }
+      ),
+      new Gossipsub(
+        libp2ps[2],
+        {
+          scoreParams: { IPColocationFactorThreshold: 20 },
+          directPeers: [{
+            id: libp2ps[1].peerId,
+            addrs: libp2ps[1].multiaddrs
+          }]
+        }
+      ),
+    ]
+    await Promise.all(psubs.map(ps => ps.start()))
+    const multicodecs = psubs[0].multicodecs
+    await libp2ps[0].dialProtocol(libp2ps[1].peerId, multicodecs)
+    await libp2ps[0].dialProtocol(libp2ps[2].peerId, multicodecs)
+
+    // verify that the direct peers connected
+    await delay(2000)
+    expect(libp2ps[1].connectionManager.get(libp2ps[2].peerId)).to.be.truthy
+
+    const topic = 'foobar'
+    psubs.forEach(ps => ps.subscribe(topic))
+
+    await delay(1000)
+
+    for (let i = 0; i < 3; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = i
+      const results = Promise.all(
+        psubs
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+
+    // disconnect the direct peers to test reconnection
+    libp2ps[1].connectionManager.getAll(libp2ps[2].peerId).forEach(c => c.close())
+
+    await delay(5000)
+
+    expect(libp2ps[1].connectionManager.get(libp2ps[2].peerId)).to.be.truthy
+
+    for (let i = 0; i < 3; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = i
+      const results = Promise.all(
+        psubs
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+  })
+  it("test gossipsub flood publish", async function () {
+    this.timeout(100000)
+    // Create 30 gossipsub nodes
+    // Connect in star topology
+    // Subscribe to the topic, all nodes
+    // Publish 20 messages, each from the center node
+    // Assert that the other nodes receive the message
+    const psubs = await createGossipsubs({
+      number: 30,
+      options: { scoreParams: { IPColocationFactorThreshold: 30 } }
+    })
+
+    await Promise.all(psubs.slice(1).map(ps => {
+      return psubs[0]._libp2p.dialProtocol(ps.peerId, ps.multicodecs)
+    }))
+
+    // build the (partial, unstable) mesh
+    const topic = 'foobar'
+    psubs.forEach(ps => ps.subscribe(topic))
+
+    await delay(1000)
+
+    // send messages from the star and assert they were received
+    for (let i = 0; i < 20; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = 0
+      const results = Promise.all(
+        psubs
+          .filter((psub, j) => j !== owner)
+          .map(checkReceivedMessage(topic, msg, owner, i))
+      )
+      await psubs[owner].publish(topic, msg)
+      await results
+    }
+  })
+  it.skip("test gossipsub negative score", async function () {
+    this.timeout(100000)
+    // Create 20 gossipsub nodes, with scoring params to quickly lower node 0's score
+    // Connect densely
+    // Subscribe to the topic, all nodes
+    // Publish 20 messages, each from a different node, collecting all received messages
+    // Assert that nodes other than 0 should not receive any messages from node 0
+    const libp2ps = await createPeers({ number: 20 })
+    const psubs = libp2ps.map(libp2p =>
+      new Gossipsub(
+        libp2p,
+        {
+          scoreParams: {
+            IPColocationFactorThreshold: 30,
+            appSpecificScore: (p) => p === libp2ps[0].peerId.toB58String() ? - 1000 : 0,
+            decayInterval: 1000,
+            decayToZero: 0.01
+          },
+          scoreThresholds: {
+            gossipThreshold: -10,
+            publishThreshold: -100,
+            graylistThreshold: -10000
+          }
+        }
+      )
+    )
+    await Promise.all(psubs.map(ps => ps.start()))
+
+    await denseConnect(psubs)
+
+    const topic = 'foobar'
+    psubs.forEach(ps => ps.subscribe(topic))
+
+    await delay(3000)
+
+    psubs.slice(1).forEach(ps => ps.on(topic, (m) => {
+      expect(m.receivedFrom).to.not.equal(libp2ps[0].peerId.toB58String())
+    }))
+
+    for (let i = 0; i < 20; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = i
+      await psubs[owner].publish(topic, msg)
+    }
+
+    await delay(2000)
+  })
+  it("test gossipsub score validator ex", async function () {
+    this.timeout(100000)
+    // Create 3 gossipsub nodes
+    // Connect fully
+    // Register a topic validator on node 0: ignore 1, reject 2
+    // Subscribe to the topic, node 0
+    // Publish 2 messages, from 1 and 2
+    // Assert that 0 received neither message
+    // Assert that 1's score is 0, 2's score is negative
+    const topic = 'foobar'
+    const psubs = await createGossipsubs({ number: 3, options: {
+      scoreParams: {
+        topics: {
+          [topic]: {
+            topicWeight: 1,
+            timeInMeshQuantum: 1000,
+            invalidMessageDeliveriesWeight: -1,
+            invalidMessageDeliveriesDecay: 0.9999
+          }
+        }
+      }
+    }})
+
+    const multicodecs = psubs[0].multicodecs
+    await psubs[0]._libp2p.dialProtocol(psubs[1].peerId, multicodecs)
+    await psubs[1]._libp2p.dialProtocol(psubs[2].peerId, multicodecs)
+    await psubs[0]._libp2p.dialProtocol(psubs[2].peerId, multicodecs)
+
+    psubs[0].topicValidators.set(topic, (topic, m) => {
+      if (m.receivedFrom === psubs[1].peerId.toB58String()) {
+        throw errcode(new Error(), constants.ERR_TOPIC_VALIDATOR_IGNORE)
+      }
+      if (m.receivedFrom === psubs[2].peerId.toB58String()) {
+        throw errcode(new Error(), constants.ERR_TOPIC_VALIDATOR_REJECT)
+      }
+    })
+
+    psubs[0].subscribe(topic)
+
+    await delay(200)
+
+    psubs[0].on(topic, () => expect.fail('node 0 should not receive any messages'))
+
+    const msg = Buffer.from('its not a flooooood')
+    await psubs[1].publish(topic, msg)
+    await psubs[2].publish(topic, msg)
+
+    await delay(2000)
+
+    expect(psubs[0].score.score(psubs[1].peerId.toB58String())).to.be.eql(0)
+    expect(psubs[0].score.score(psubs[2].peerId.toB58String())).to.be.lt(0)
+  })
+  it("test gossipsub piggyback control", async function () {
+    this.timeout(100000)
+    const libp2ps = await createPeers({ number: 2 })
+    const otherId = libp2ps[1].peerId.toB58String()
+    const psub = new Gossipsub(libp2ps[0])
+    await psub.start()
+
+    const test1 = 'test1'
+    const test2 = 'test2'
+    const test3 = 'test3'
+    psub.mesh.set(test1, new Set([otherId]))
+    psub.mesh.set(test2, new Set())
+
+    const rpc = {}
+    psub._piggybackControl(otherId, rpc, {
+      graft: [
+        { topicID: test1 },
+        { topicID: test2 },
+        { topicID: test3 }
+      ],
+      prune: [
+        { topicID: test1 },
+        { topicID: test2 },
+        { topicID: test3 }
+      ],
+    })
+
+    expect(rpc.control).to.be.truthy
+    expect(rpc.control.graft.length).to.be.eql(1)
+    expect(rpc.control.graft[0].topicID).to.be.eql(test1)
+    expect(rpc.control.prune.length).to.be.eql(2)
+    expect(rpc.control.prune[0].topicID).to.be.eql(test2)
+    expect(rpc.control.prune[1].topicID).to.be.eql(test3)
+  })
+  it("test gossipsub opportunistic grafting", async function () {
+    this.timeout(100000)
+    // Create 50 nodes
+    // 10 real gossip nodes, 40 'sybil' nodes, unresponsive nodes
+    // Connect some of the real nodes
+    // Connect every sybil to every real node
+    // Subscribe to the topic, all real nodes
+    // Publish 1000 messages from the real nodes
+    // Wait for opgraft
+    // Assert the real peer meshes have at least 3 honest peers
+    sinon.replace(constants, 'GossipsubPruneBackoff', 500)
+    sinon.replace(constants, 'GossipsubGraftFloodThreshold', 100)
+    sinon.replace(constants, 'GossipsubOpportunisticGraftPeers', 2)
+    sinon.replace(constants, 'GossipsubOpportunisticGraftTicks', 2)
+    const topic = 'test'
+    const psubs = await createGossipsubs({
+      number: 50,
+      options: {
+        scoreParams: {
+          IPColocationFactorThreshold: 50,
+          decayToZero: 0.01,
+          topics: {
+            [topic]: {
+              topicWeight: 1,
+              timeInMeshWeight: 0.00002777,
+              timeInMeshQuantum: 1000,
+              timeInMeshCap: 3600,
+              firstMessageDeliveriesWeight: 10,
+              firstMessageDeliveriesDecay: 0.99997,
+              firstMessageDeliveriesCap: 100,
+              meshMessageDeliveriesWeight: 0,
+              invalidMessageDeliveriesDecay: 0.99997,
+            }
+          }
+        },
+        scoreThresholds: {
+          gossipThreshold: -10,
+          publishThreshold: -100,
+          graylistThreshold: -10000,
+          opportunisticGraftThreshold: 1
+        }
+      }
+    })
+    const real = psubs.slice(0, 10)
+    const sybils = psubs.slice(10)
+
+    await connectSome(real, 5)
+
+    sybils.forEach(s => {
+      s._processRpc = function () {}
+    })
+
+    for (let i = 0; i < sybils.length; i++) {
+      for (let j = 0; j < real.length; j++) {
+        await connectGossipsub(sybils[i], real[j])
+      }
+    }
+
+    await delay(1000)
+
+    psubs.forEach(ps => ps.subscribe(topic))
+
+    for (let i = 0; i < 100; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = i % 10
+      await psubs[owner].publish(topic, msg)
+      await delay(40)
+    }
+
+    await delay(7000)
+
+    for (let i = 0; i < 100; i++) {
+      const msg = Buffer.from(`${i} its not a flooooood ${i}`)
+      const owner = i % 10
+      await psubs[owner].publish(topic, msg)
+      await delay(40)
+    }
+
+    // now wait for opgraft cycles
+    await delay(7000)
+
+    // check the honest node meshes, they should have at least 3 honest peers each
+    const realPeerIds = real.map(r => r.peerId.toB58String())
+    const sybilPeerIds = sybils.map(r => r.peerId.toB58String())
+    real.forEach((r, i) => {
+      const meshPeers = r.mesh.get(topic)
+      let count = 0
+      realPeerIds.forEach(p => {
+        if (meshPeers.has(p)) {
+          count++
+        }
+      })
+      expect(count).to.be.gte(3)
+    })
+  })
+})

--- a/test/go-gossipsub.spec.js
+++ b/test/go-gossipsub.spec.js
@@ -43,7 +43,7 @@ const checkReceivedMessage = (topic, data, senderIx, msgIx) =>
     })
   })
 
-describe.skip("go-libp2p-pubsub gossipsub tests", () => {
+describe("go-libp2p-pubsub gossipsub tests", () => {
   afterEach(() => {
     sinon.restore()
   })
@@ -312,7 +312,7 @@ describe.skip("go-libp2p-pubsub gossipsub tests", () => {
     // and wait for some gossip flushing
     await delay(2000)
   })
-  it.skip("test gossipsub gossip propagation", async function () {
+  it("test gossipsub gossip propagation", async function () {
     this.timeout(100000)
     // Create 20 gossipsub nodes
     // Split into two groups, only a single node shared between
@@ -521,7 +521,7 @@ describe.skip("go-libp2p-pubsub gossipsub tests", () => {
       await results
     }
   })
-  it.skip("test gossipsub control piggyback", async function () {
+  it("test gossipsub control piggyback", async function () {
     this.timeout(100000)
     // Create 10 gossipsub nodes
     // Densely connect nodes
@@ -884,7 +884,7 @@ describe.skip("go-libp2p-pubsub gossipsub tests", () => {
       await results
     }
   })
-  it.skip("test gossipsub negative score", async function () {
+  it("test gossipsub negative score", async function () {
     this.timeout(100000)
     // Create 20 gossipsub nodes, with scoring params to quickly lower node 0's score
     // Connect densely

--- a/test/node.js
+++ b/test/node.js
@@ -1,0 +1,3 @@
+'use strict'
+
+require('./go-gossipsub')

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1029,6 +1029,11 @@ class Gossipsub extends Pubsub {
    * @returns {void}
    */
   async _publish (msg: InMessage): Promise<void> {
+    if (msg.receivedFrom !== this.peerId.toB58String()) {
+      this.score.deliverMessage(msg)
+      this.gossipTracer.deliverMessage(msg)
+    }
+
     const msgID = this.getMsgId(msg)
     // put in seen cache
     this.seenCache.put(msgID)


### PR DESCRIPTION
Add go gossipsub tests from: https://github.com/libp2p/go-libp2p-pubsub/blob/master/gossipsub_test.go
A few irrelevant tests have been left out.

A few bugs have been found in the course of running these tests, see #115
A few tests are flaky, a few are failing (after #115)