### PR TITLE
gs1.1: chore: ignore messages from unsubbed topics

### DIFF
--- a/ts/pubsub.js
+++ b/ts/pubsub.js
@@ -164,6 +164,10 @@ class BasicPubSub extends Pubsub {
 
     if (msgs.length) {
       msgs.forEach(message => {
+        if (!message.topicIDs.some((topic) => this.subscriptions.has(topic))) {
+          this.log('received message we didn\'t subscribe to. Dropping.')
+          return
+        }
         const msg = utils.normalizeInRpcMessage(message, PeerId.createFromB58String(idB58Str))
         this._processRpcMessage(msg)
       })


### PR DESCRIPTION
Previously, we would process any messages we received, even messages in unsubbed topics.