### PR TITLE
chore: consolidate publish functionality

### DIFF
--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -43,7 +43,7 @@ describe('Pubsub', () => {
       await gossipsub.publish('signing-topic', Buffer.from('hello'))
 
       // Get the first message sent to _publish, and validate it
-      const signedMessage = await gossipsub._buildMessage(gossipsub._publish.getCall(0).lastArg)
+      const signedMessage = gossipsub._publish.getCall(0).lastArg
       try {
         await gossipsub.validate(signedMessage)
       } catch (e) {
@@ -57,7 +57,7 @@ describe('Pubsub', () => {
 
     it('should drop unsigned messages', async () => {
       sinon.spy(gossipsub, '_processRpcMessage')
-      sinon.spy(gossipsub, '_publishFrom')
+      sinon.spy(gossipsub, '_publish')
       sinon.stub(gossipsub.peers, 'get').returns({})
 
       const peer = new PeerStreams({ id: await PeerId.create() })
@@ -75,14 +75,14 @@ describe('Pubsub', () => {
       gossipsub.unsubscribe(topic)
 
       return new Promise(resolve => setTimeout(async () => {
-        expect(gossipsub._publishFrom.callCount).to.eql(0)
+        expect(gossipsub._publish.callCount).to.eql(0)
         resolve()
       }, 500))
     })
 
     it('should not drop signed messages', async () => {
       sinon.spy(gossipsub, '_processRpcMessage')
-      sinon.spy(gossipsub, '_publishFrom')
+      sinon.spy(gossipsub, '_publish')
       sinon.stub(gossipsub.peers, 'get').returns({})
 
       const peer = new PeerStreams({ id: await PeerId.create() })
@@ -104,14 +104,14 @@ describe('Pubsub', () => {
       gossipsub.unsubscribe(topic)
 
       return new Promise(resolve => setTimeout(async () => {
-        expect(gossipsub._publishFrom.callCount).to.eql(1)
+        expect(gossipsub._publish.callCount).to.eql(1)
         resolve()
       }, 500))
     })
 
     it('should not drop unsigned messages if strict signing is disabled', async () => {
       sinon.spy(gossipsub, '_processRpcMessage')
-      sinon.spy(gossipsub, '_publishFrom')
+      sinon.spy(gossipsub, '_publish')
       sinon.stub(gossipsub.peers, 'get').returns({})
       // Disable strict signing
       sinon.stub(gossipsub, 'strictSigning').value(false)
@@ -132,7 +132,7 @@ describe('Pubsub', () => {
       gossipsub.unsubscribe(topic)
 
       return new Promise(resolve => setTimeout(async () => {
-        expect(gossipsub._publishFrom.callCount).to.eql(1)
+        expect(gossipsub._publish.callCount).to.eql(1)
         resolve()
       }, 500))
     })
@@ -140,8 +140,8 @@ describe('Pubsub', () => {
 
   describe('topic validators', () => {
     it('should filter messages by topic validator', async () => {
-      // use _publishFrom.callCount() to see if a message is valid or not
-      sinon.spy(gossipsub, '_publishFrom')
+      // use _publish.callCount() to see if a message is valid or not
+      sinon.spy(gossipsub, '_publish')
       // Disable strict signing
       sinon.stub(gossipsub, 'strictSigning').value(false)
       sinon.stub(gossipsub.peers, 'get').returns({})
@@ -170,7 +170,7 @@ describe('Pubsub', () => {
       gossipsub.subscribe(filteredTopic)
       gossipsub._processRpc(peer.id.toB58String(), peer, validRpc)
       await delay(500)
-      expect(gossipsub._publishFrom.callCount).to.eql(1)
+      expect(gossipsub._publish.callCount).to.eql(1)
 
       // invalid case
       const invalidRpc = {
@@ -186,7 +186,7 @@ describe('Pubsub', () => {
       // process invalid message
       gossipsub._processRpc(peer.id.toB58String(), peer, invalidRpc)
       await delay(500)
-      expect(gossipsub._publishFrom.callCount).to.eql(1)
+      expect(gossipsub._publish.callCount).to.eql(1)
 
       // remove topic validator
       gossipsub.topicValidators.delete(filteredTopic)
@@ -206,7 +206,7 @@ describe('Pubsub', () => {
       gossipsub._processRpc(peer.id.toB58String(), peer, invalidRpc2)
       gossipsub.unsubscribe(filteredTopic)
       await delay(500)
-      expect(gossipsub._publishFrom.callCount).to.eql(2)
+      expect(gossipsub._publish.callCount).to.eql(2)
     })
   })
 })

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -381,57 +381,6 @@ class Gossipsub extends BasicPubsub {
   }
 
   /**
-   * Publish a message sent from a peer
-   * @override
-   * @param {InMessage} msg
-   * @returns {void}
-   */
-  _publishFrom (msg: InMessage): void {
-    this.score.deliverMessage(msg)
-    this.gossipTracer.deliverMessage(msg)
-    const topics = msg.topicIDs
-    const rpc = createGossipRpc([
-      utils.normalizeOutRpcMessage(msg)
-    ])
-
-    // If options.gossipIncoming is false, do NOT emit incoming messages to peers
-    if (this._options.gossipIncoming) {
-      // Emit to floodsub peers
-      this.peers.forEach((peer, id) => {
-        if (
-          peer.protocol === constants.FloodsubID &&
-          id !== msg.from &&
-          topics.some(topic => {
-            const t = this.topics.get(topic)
-            return t && t.has(id)
-          })
-        ) {
-          this._sendRpc(id, rpc)
-          this.log('publish msg on topics - floodsub', topics, id)
-        }
-      })
-
-      // Emit to peers in the mesh
-      topics.forEach((topic) => {
-        const meshPeers = this.mesh.get(topic)
-        if (!meshPeers) {
-          return
-        }
-        meshPeers.forEach((id) => {
-          if (id === msg.from) {
-            return
-          }
-          this._sendRpc(id, rpc)
-          this.log('publish msg on topic - meshsub', topic, id)
-        })
-      })
-    }
-
-    // Emit to self
-    super._publishFrom(msg)
-  }
-
-  /**
    * Whether to accept a message from a peer
    * @override
    * @param {string} id
@@ -599,8 +548,7 @@ class Gossipsub extends BasicPubsub {
         return
       }
       const peersInMesh = this.mesh.get(topicID)
-      const peersInTopic = this.topics.get(topicID)
-      if (!peersInMesh || !peersInTopic) {
+      if (!peersInMesh) {
         // don't do PX when there is an unknown topic to avoid leaking our peers
         doPX = false
         // spam hardening: ignore GRAFTs for unknown topics
@@ -1034,10 +982,6 @@ class Gossipsub extends BasicPubsub {
    * @returns {void}
    */
   async _publish (msg: InMessage): Promise<void> {
-    // ensure that any operations performed on the message will include the signature
-    const outMsg = await this._buildMessage(msg)
-    msg = utils.normalizeInRpcMessage(outMsg)
-
     const msgID = this.getMsgId(msg)
     // put in seen cache
     this.seenCache.put(msgID)
@@ -1051,7 +995,7 @@ class Gossipsub extends BasicPubsub {
         return
       }
 
-      if (this._options.floodPublish) {
+      if (this._options.floodPublish && msg.from === this.peerId.toB58String()) {
         // flood-publish behavior
         // send to direct peers and _all_ peers meeting the publishThreshold
         peersInTopic.forEach(id => {
@@ -1109,7 +1053,9 @@ class Gossipsub extends BasicPubsub {
       }
     })
     // Publish messages to peers
-    const rpc = createGossipRpc([outMsg])
+    const rpc = createGossipRpc([
+      utils.normalizeOutRpcMessage(msg)
+    ])
     tosend.forEach((id) => {
       if (id === msg.from) {
         return

--- a/ts/pubsub.js
+++ b/ts/pubsub.js
@@ -243,17 +243,9 @@ class BasicPubSub extends Pubsub {
       return
     }
 
-    this._publishFrom(msg)
-  }
-
-  /**
-   * Publish a message sent from a peer
-   * @param {InMessage} msg
-   * @returns {void}
-   */
-  _publishFrom (msg) {
-    // Emit to self
     this._emitMessage(msg)
+
+    this._publish(msg)
   }
 
   /**
@@ -369,13 +361,16 @@ class BasicPubSub extends Pubsub {
 
     const from = this.peerId.toB58String()
 
-    const msgObject = {
+    let msgObject = {
       receivedFrom: from,
       from: from,
       data: message,
       seqno: utils.randomSeqno(),
       topicIDs: topics
     }
+    // ensure that any operations performed on the message will include the signature
+    const outMsg = await this._buildMessage(msgObject)
+    msgObject = utils.normalizeInRpcMessage(outMsg)
 
     // Emit to self if I'm interested and emitSelf enabled
     this._options.emitSelf && this._emitMessage(msgObject)


### PR DESCRIPTION
Remove separate `_publishFrom` function, instead use `_publish`.

Instead of having separate functions for messages published from self vs from others, consolidate all publish functionality into a single `_publish` function. This allows us to remove duplicated code. It also more closely follows the go-libp2p-gossipsub implementation.