### PR TITLE
fix: pick uintarrays commit

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -56,5 +56,11 @@ module.exports = {
   hooks: {
     pre: before,
     post: after
+  },
+  webpack: {
+    node: {
+      // this is needed until bcrypto stops using node buffers in browser code
+      Buffer: true
+    }
   }
 }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ gsub.on('fruit', (data) => {
 })
 gsub.subscribe('fruit')
 
-gsub.publish('fruit', new Buffer('banana'))
+gsub.publish('fruit', new TextEncoder().encode('banana'))
 ```
 
 ## API

--- a/benchmarks/benchmarks.js
+++ b/benchmarks/benchmarks.js
@@ -25,7 +25,7 @@ const suite = new Benchmark.Suite('gossipsub')
   suite
     .add('publish and receive', (deferred) => {
       peers[1].gs.once('Z', (msg) => deferred.resolve(msg))
-      peers[0].gs.publish('Z', Buffer.alloc(1024))
+      peers[0].gs.publish('Z', new Uint8Array(1024))
     }, {
       defer: true
     })

--- a/package.json
+++ b/package.json
@@ -38,14 +38,13 @@
     "lint"
   ],
   "dependencies": {
-    "buffer": "^5.6.0",
     "debug": "^4.1.1",
     "denque": "^1.4.1",
     "err-code": "^2.0.0",
     "it-pipe": "^1.0.1",
     "libp2p-pubsub": "https://github.com/libp2p/js-libp2p-pubsub#v0.6.x",
-    "peer-id": "~0.13.12",
-    "protons": "^1.0.1",
+    "peer-id": "^0.14.0",
+    "protons": "^2.0.0",
     "time-cache": "^0.3.0"
   },
   "devDependencies": {
@@ -53,7 +52,7 @@
     "@types/mocha": "^7.0.2",
     "@typescript-eslint/eslint-plugin": "^3.0.2",
     "@typescript-eslint/parser": "^3.0.2",
-    "aegir": "^21.10.2",
+    "aegir": "^25.0.0",
     "benchmark": "^2.1.4",
     "chai": "^4.2.0",
     "chai-spies": "^1.0.0",
@@ -79,7 +78,8 @@
     "p-wait-for": "^3.1.0",
     "promisify-es6": "^1.0.3",
     "sinon": "^9.0.2",
-    "typescript": "^3.9.3"
+    "typescript": "^3.9.3",
+    "uint8arrays": "^1.1.0"
   },
   "peerDependencies": {
     "libp2p": "https://github.com/libp2p/js-libp2p#0.29.x"

--- a/test/2-nodes.spec.js
+++ b/test/2-nodes.spec.js
@@ -1,12 +1,14 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 chai.use(require('chai-spies'))
 const expect = chai.expect
+
 const delay = require('delay')
+const uint8ArrayFromString = require('uint8arrays/from-string')
+
 
 const { multicodec } = require('../src')
 const Gossipsub = require('../src')
@@ -148,7 +150,7 @@ describe('2 nodes', () => {
       const promise = new Promise((resolve) => nodes[1].once(topic, resolve))
       nodes[0].once(topic, (m) => shouldNotHappen)
 
-      nodes[0].publish(topic, Buffer.from('hey'))
+      nodes[0].publish(topic, uint8ArrayFromString('hey'))
 
       const msg = await promise
 
@@ -162,7 +164,7 @@ describe('2 nodes', () => {
       const promise = new Promise((resolve) => nodes[0].once(topic, resolve))
       nodes[1].once(topic, shouldNotHappen)
 
-      nodes[1].publish(topic, Buffer.from('banana'))
+      nodes[1].publish(topic, uint8ArrayFromString('banana'))
 
       const msg = await promise
 
@@ -182,7 +184,7 @@ describe('2 nodes', () => {
       function receivedMsg (msg) {
         expect(msg.data.toString()).to.equal('banana')
         expect(msg.from).to.be.eql(nodes[1].peerId.toB58String())
-        expect(Buffer.isBuffer(msg.seqno)).to.be.true()
+        expect(msg.seqno).to.be.a('Uint8Array')
         expect(msg.topicIDs).to.be.eql([topic])
 
         if (++counter === 10) {
@@ -193,7 +195,7 @@ describe('2 nodes', () => {
       }
 
       Array.from({ length: 10 }).forEach(() => {
-        nodes[1].publish(topic, Buffer.from('banana'))
+        nodes[1].publish(topic, uint8ArrayFromString('banana'))
       })
     })
   })
@@ -250,8 +252,8 @@ describe('2 nodes', () => {
         }, 100)
       })
 
-      nodes[1].publish('Z', Buffer.from('banana'))
-      nodes[0].publish('Z', Buffer.from('banana'))
+      nodes[1].publish('Z', uint8ArrayFromString('banana'))
+      nodes[0].publish('Z', uint8ArrayFromString('banana'))
 
       try {
         await promise

--- a/test/emit-self.spec.js
+++ b/test/emit-self.spec.js
@@ -1,10 +1,11 @@
 /* eslint-env mocha */
 'use strict'
-const { Buffer } = require('buffer')
+
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 chai.use(require('chai-spies'))
 const expect = chai.expect
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const Gossipsub = require('../src')
 const {
@@ -31,7 +32,8 @@ describe('emit self', () => {
     it('should emit to self on publish', async () => {
       gossipsub.subscribe(topic)
       const promise = new Promise((resolve) => gossipsub.once(topic, resolve))
-      gossipsub.publish(topic, Buffer.from('hey'))
+
+      gossipsub.publish(topic, uint8ArrayFromString('hey'))
 
       await promise
     })
@@ -49,7 +51,7 @@ describe('emit self', () => {
       gossipsub.subscribe(topic)
       gossipsub.once(topic, (m) => shouldNotHappen)
 
-      gossipsub.publish(topic, Buffer.from('hey'))
+      gossipsub.publish(topic, uint8ArrayFromString('hey'))
 
       // Wait 1 second to guarantee that self is not noticed
       await new Promise((resolve) => setTimeout(() => resolve(), 1000))

--- a/test/floodsub.spec.js
+++ b/test/floodsub.spec.js
@@ -1,16 +1,15 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
 const chai = require('chai')
 chai.use(require('dirty-chai'))
+
 const delay = require('delay')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const expect = chai.expect
 const times = require('lodash/times')
 const PeerId = require('peer-id')
-
-const { multicodec: floodsubMulticodec } = require('libp2p-floodsub')
 
 const Gossipsub = require('../src')
 const {
@@ -176,7 +175,7 @@ describe('gossipsub fallbacks to floodsub', () => {
       const promise = new Promise((resolve) => nodeFs.once(topic, resolve))
       nodeGs.once(topic, (m) => shouldNotHappen)
 
-      nodeGs.publish(topic, Buffer.from('hey'))
+      nodeGs.publish(topic, uint8ArrayFromString('hey'))
 
       const msg = await promise
       expect(msg.data.toString()).to.equal('hey')
@@ -188,7 +187,7 @@ describe('gossipsub fallbacks to floodsub', () => {
     it('Publish to a topic - nodeFs', async () => {
       const promise = new Promise((resolve) => nodeGs.once(topic, resolve))
 
-      nodeFs.publish(topic, Buffer.from('banana'))
+      nodeFs.publish(topic, uint8ArrayFromString('banana'))
 
       const msg = await promise
 
@@ -209,7 +208,7 @@ describe('gossipsub fallbacks to floodsub', () => {
       function receivedMsg (msg) {
         expect(msg.data.toString()).to.equal('banana ' + counter)
         expect(msg.from).to.be.eql(nodeGs.peerId.toB58String())
-        expect(Buffer.isBuffer(msg.seqno)).to.be.true()
+        expect(msg.seqno).to.be.a('Uint8Array')
         expect(msg.topicIDs).to.be.eql([topic])
 
         if (++counter === 10) {
@@ -219,7 +218,7 @@ describe('gossipsub fallbacks to floodsub', () => {
         }
       }
 
-      times(10, (index) => nodeGs.publish(topic, Buffer.from('banana ' + index)))
+      times(10, (index) => nodeGs.publish(topic, uint8ArrayFromString('banana ' + index)))
     })
 
     it('Publish 10 msg to a topic as array', (done) => {
@@ -236,7 +235,7 @@ describe('gossipsub fallbacks to floodsub', () => {
       function receivedMsg (msg) {
         expect(msg.data.toString()).to.equal('banana ' + counter)
         expect(msg.from).to.be.eql(nodeGs.peerId.toB58String())
-        expect(Buffer.isBuffer(msg.seqno)).to.be.true()
+        expect(msg.seqno).to.be.a('Uint8Array')
         expect(msg.topicIDs).to.be.eql([topic])
 
         if (++counter === 10) {
@@ -247,7 +246,7 @@ describe('gossipsub fallbacks to floodsub', () => {
       }
 
       const msgs = []
-      times(10, (index) => msgs.push(Buffer.from('banana ' + index)))
+      times(10, (index) => msgs.push(uint8ArrayFromString('banana ' + index)))
       msgs.forEach(msg => nodeGs.publish(topic, msg))
     })
   })
@@ -314,8 +313,8 @@ describe('gossipsub fallbacks to floodsub', () => {
         }, 100)
       })
 
-      nodeFs.publish('Z', Buffer.from('banana'))
-      nodeGs.publish('Z', Buffer.from('banana'))
+      nodeFs.publish('Z', uint8ArrayFromString('banana'))
+      nodeGs.publish('Z', uint8ArrayFromString('banana'))
 
       try {
         await promise

--- a/test/gossip-incoming.spec.js
+++ b/test/gossip-incoming.spec.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 'use strict'
 
-const { Buffer } = require('buffer')
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 chai.use(require('chai-spies'))
 const expect = chai.expect
-const delay = require('delay')
 
-const { GossipsubIDv11: multicodec } = require('../src/constants')
+const delay = require('delay')
+const uint8ArrayFromString = require('uint8arrays/from-string')
+
 const {
   createConnectedGossipsubs,
   stopNode
@@ -47,7 +47,7 @@ describe('gossip incoming', () => {
       const promise = new Promise((resolve) => nodes[2].once(topic, resolve))
       nodes[0].once(topic, (m) => shouldNotHappen)
 
-      nodes[0].publish(topic, Buffer.from('hey'))
+      nodes[0].publish(topic, uint8ArrayFromString('hey'))
 
       const msg = await promise
 
@@ -84,7 +84,7 @@ describe('gossip incoming', () => {
     it('should not gossip incoming messages', async () => {
       nodes[2].once(topic, (m) => shouldNotHappen)
 
-      nodes[0].publish(topic, Buffer.from('hey'))
+      nodes[0].publish(topic, uint8ArrayFromString('hey'))
 
       await delay(1000)
 

--- a/test/messageCache.spec.js
+++ b/test/messageCache.spec.js
@@ -1,13 +1,14 @@
 /* eslint-env mocha */
 /* eslint-disable no-unused-expressions */
 'use strict'
-const { Buffer } = require('buffer')
+
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 chai.use(dirtyChai)
 const chaiSpies = require('chai-spies')
 chai.use(chaiSpies)
 const expect = chai.expect
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 const { MessageCache } = require('../src/messageCache')
 const { utils } = require('libp2p-pubsub')
@@ -24,7 +25,7 @@ describe('Testing Message Cache Operations', () => {
     const makeTestMessage = (n) => {
       return {
         from: 'test',
-        data: Buffer.from(n.toString()),
+        data: uint8ArrayFromString(n.toString()),
         seqno: utils.randomSeqno(),
         topicIDs: ['test']
       }

--- a/test/multiple-nodes.spec.js
+++ b/test/multiple-nodes.spec.js
@@ -1,14 +1,15 @@
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 8] */
 'use strict'
-const { Buffer } = require('buffer')
+
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
-const promisify = require('promisify-es6')
-const delay = require('delay')
 
-const { GossipsubIDv11: multicodec } = require('../src/constants')
+const delay = require('delay')
+const promisify = require('promisify-es6')
+const uint8ArrayFromString = require('uint8arrays/from-string')
+
 const {
   createGossipsubs,
   expectSet,
@@ -111,7 +112,7 @@ describe('multiple nodes (more than 2)', () => {
           let msgB = new Promise((resolve) => b.once('Z', resolve))
           let msgC = new Promise((resolve) => c.once('Z', resolve))
 
-          a.publish('Z', Buffer.from('hey'))
+          a.publish('Z', uint8ArrayFromString('hey'))
           msgB = await msgB
           msgC = await msgC
 
@@ -162,7 +163,7 @@ describe('multiple nodes (more than 2)', () => {
         let msgA = new Promise((resolve) => a.once('Z', resolve))
         let msgC = new Promise((resolve) => c.once('Z', resolve))
 
-        b.publish('Z', Buffer.from('hey'))
+        b.publish('Z', uint8ArrayFromString('hey'))
         msgA = await msgA
         msgC = await msgC
 
@@ -227,7 +228,7 @@ describe('multiple nodes (more than 2)', () => {
         let msgE = new Promise((resolve) => e.once('Z', resolve))
 
         const msg = 'hey from c'
-        c.publish('Z', Buffer.from(msg))
+        c.publish('Z', uint8ArrayFromString(msg))
 
         msgA = await msgA
         msgB = await msgB

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -1,13 +1,15 @@
 'use strict'
 /* eslint-env mocha */
 /* eslint max-nested-callbacks: ["error", 5] */
-const { Buffer } = require('buffer')
+
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 const sinon = require('sinon')
+
 const delay = require('delay')
-const errcode = require('err-code')
+const uint8ArrayFromString = require('uint8arrays/from-string')
+const uint8ArrayEquals = require('uint8arrays/equals')
 
 const { utils } = require('libp2p-pubsub')
 const PeerStreams = require('libp2p-pubsub/src/peerStreams')
@@ -40,7 +42,7 @@ describe('Pubsub', () => {
     it('should sign messages on publish', async () => {
       sinon.spy(gossipsub, '_publish')
 
-      await gossipsub.publish('signing-topic', Buffer.from('hello'))
+      await gossipsub.publish('signing-topic', uint8ArrayFromString('hello'))
 
       // Get the first message sent to _publish, and validate it
       const signedMessage = await gossipsub._buildMessage(gossipsub._publish.getCall(0).lastArg)
@@ -65,7 +67,7 @@ describe('Pubsub', () => {
         subscriptions: [],
         msgs: [{
           from: peer.id.toBytes(),
-          data: Buffer.from('an unsigned message'),
+          data: uint8ArrayFromString('an unsigned message'),
           seqno: utils.randomSeqno(),
           topicIDs: [topic]
         }]
@@ -88,7 +90,7 @@ describe('Pubsub', () => {
       const peer = new PeerStreams({ id: await PeerId.create() })
       let signedMessage = {
         from: peer.id.toB58String(),
-        data: Buffer.from('a signed message'),
+        data: uint8ArrayFromString('an unsigned message'),
         seqno: utils.randomSeqno(),
         topicIDs: [topic]
       }
@@ -121,7 +123,7 @@ describe('Pubsub', () => {
         subscriptions: [],
         msgs: [{
           from: peer.id.toBytes(),
-          data: Buffer.from('an unsigned message'),
+          data: uint8ArrayFromString('an unsigned message'),
           seqno: utils.randomSeqno(),
           topicIDs: [topic]
         }]
@@ -150,7 +152,7 @@ describe('Pubsub', () => {
 
       // Set a trivial topic validator
       gossipsub.topicValidators.set(filteredTopic, (topic, message) => {
-        if (!message.data.equals(Buffer.from('a message'))) {
+        if(!uint8ArrayEquals(message.data, uint8ArrayFromString('a message'))) {
           throw errcode(new Error(), ERR_TOPIC_VALIDATOR_REJECT)
         }
       })
@@ -160,7 +162,7 @@ describe('Pubsub', () => {
         subscriptions: [],
         msgs: [{
           from: peer.id.toBytes(),
-          data: Buffer.from('a message'),
+          data: uint8ArrayFromString('a message'),
           seqno: utils.randomSeqno(),
           topicIDs: [filteredTopic]
         }]
@@ -177,7 +179,7 @@ describe('Pubsub', () => {
         subscriptions: [],
         msgs: [{
           from: peer.id.toBytes(),
-          data: Buffer.from('a different message'),
+          data: uint8ArrayFromString('a different message'),
           seqno: utils.randomSeqno(),
           topicIDs: [filteredTopic]
         }]
@@ -196,7 +198,7 @@ describe('Pubsub', () => {
         subscriptions: [],
         msgs: [{
           from: peer.id.toB58String(),
-          data: Buffer.from('a different message'),
+          data: uint8ArrayFromString('a different message'),
           seqno: utils.randomSeqno(),
           topicIDs: [filteredTopic]
         }]

--- a/ts/message/index.ts
+++ b/ts/message/index.ts
@@ -31,17 +31,17 @@ export interface Message {
    *
    * Note: This is not necessarily the peer who sent the RPC this message is contained in
    */
-  from?: Buffer
+  from?: Uint8Array
   /**
    * Opaque blob of data
    */
-  data?: Buffer
+  data?: Uint8Array
   /**
    * 64-bit big-endian uint
    *
    * No two messages on a topic from the same peer should have the same seqno value
    */
-  seqno?: Buffer
+  seqno?: Uint8Array
   /**
    * Set of topics being published to
    */
@@ -52,11 +52,11 @@ export interface Message {
    * The signature is computed over the marshalled message protobuf excluding the key field
    * The protobuf bloc is prefixed by the string `libp2p-pubsub:` before signing
    */
-  signature?: Buffer
+  signature?: Uint8Array
   /**
    * Signing key
    */
-  key?: Buffer
+  key?: Uint8Array
 }
 
 type Overwrite<T1, T2> = {
@@ -113,7 +113,7 @@ export interface ControlPrune {
 }
 
 export interface PeerInfo {
-  peerID?: Buffer
+  peerID?: Uint8Array
   signedPeerRecord?: Buffer
 }
 
@@ -137,8 +137,8 @@ export interface RPC {
 }
 
 interface ProtoCodec<T> {
-  encode(obj: T): Buffer
-  decode(buf: Buffer): T
+  encode(obj: T): Uint8Array
+  decode(buf: Uint8Array): T
 }
 
 export const RPCCodec = rpcProto.RPC as ProtoCodec<RPC>

--- a/ts/peerStreams.ts
+++ b/ts/peerStreams.ts
@@ -5,12 +5,12 @@ import { DuplexIterableStream } from './interfaces'
 export interface PeerStreams {
   id: PeerId
   protocol: string
-  outboundStream: Pushable<Buffer>
+  outboundStream: Pushable<Uint8Array>
   inboundStream: DuplexIterableStream
   readonly isReadable: boolean
   readonly isWritable: boolean
   attachInboundConnection (stream: DuplexIterableStream): void
   attachOutboundConnection (stream: DuplexIterableStream): Promise<void>
-  write (buf: Buffer): void
+  write (buf: Uint8Array): void
   close (): void
 }

--- a/ts/pubsub.js
+++ b/ts/pubsub.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const errcode = require('err-code')
-const { Buffer } = require('buffer')
 const PeerId = require('peer-id')
 
 const pipe = require('it-pipe')
@@ -102,7 +101,7 @@ class BasicPubSub extends Pubsub {
         stream,
         async (source) => {
           for await (const data of source) {
-            const rpcMsgBuf = Buffer.isBuffer(data) ? data : data.slice()
+            const rpcMsgBuf = data instanceof Uint8Array ? data : data.slice()
             const rpcMsg = this._decodeRpc(rpcMsgBuf)
 
             this._processRpc(idB58Str, peerStreams, rpcMsg)
@@ -115,11 +114,11 @@ class BasicPubSub extends Pubsub {
   }
 
   /**
-   * Decode a buffer into an RPC object
+   * Decode a Uint8Array into an RPC object
    *
    * Override to use an extended protocol-specific protobuf decoder
    *
-   * @param {Buffer} buf
+   * @param {Uint8Array} buf
    * @returns {RPC}
    */
   _decodeRpc (buf) {
@@ -127,12 +126,12 @@ class BasicPubSub extends Pubsub {
   }
 
   /**
-   * Encode an RPC object into a buffer
+   * Encode an RPC object into a Uint8Array
    *
    * Override to use an extended protocol-specific protobuf encoder
    *
    * @param {RPC} rpc
-   * @returns {Buffer}
+   * @returns {Uint8Array}
    */
   _encodeRpc (rpc) {
     return RPCCodec.encode(rpc)


### PR DESCRIPTION
Pick commit from #118 

Note: the signed peer records side of things is still using Buffers. This should be fixed in a follow up PR as it needs also to be updated in libp2p@0.29 branch