### PR TITLE
chore: use libp2p-interfaces0.5.1 and libp2p0.29 rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "it-pair": "^1.0.0",
     "libp2p": "https://github.com/libp2p/js-libp2p#0.29.x",
-    "libp2p-floodsub": "https://github.com/libp2p/js-libp2p-floodsub#chore/update-pubsub",
+    "libp2p-floodsub": "^0.23.0",
     "libp2p-mplex": "^0.10.0",
     "libp2p-noise": "^2.0.0",
     "libp2p-websockets": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "it-pair": "^1.0.0",
-    "libp2p": "https://github.com/libp2p/js-libp2p#0.29.x",
+    "libp2p": "^0.29.0-rc.0",
     "libp2p-floodsub": "^0.23.0",
     "libp2p-mplex": "^0.10.0",
     "libp2p-noise": "^2.0.0",
@@ -84,7 +84,7 @@
     "uint8arrays": "^1.1.0"
   },
   "peerDependencies": {
-    "libp2p": "https://github.com/libp2p/js-libp2p#0.29.x"
+    "libp2p": "^0.29.0-rc.0"
   },
   "contributors": [
     "Cayman <caymannava@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "denque": "^1.4.1",
     "err-code": "^2.0.0",
     "it-pipe": "^1.0.1",
-    "libp2p-interfaces": "libp2p/js-libp2p-interfaces#feat/interface-pubsub",
+    "libp2p-interfaces": "^0.5.1",
     "peer-id": "^0.14.0",
     "protons": "^2.0.0",
     "time-cache": "^0.3.0"

--- a/test/floodsub.spec.js
+++ b/test/floodsub.spec.js
@@ -194,61 +194,6 @@ describe('gossipsub fallbacks to floodsub', () => {
       expect(msg.data.toString()).to.equal('banana')
       expect(msg.from).to.be.eql(nodeFs.peerId.toB58String())
     })
-
-    it('Publish 10 msg to a topic', (done) => {
-      let counter = 0
-
-      const shouldNotHappen = (msg) => {
-        done(new Error('Should not be here'))
-      }
-
-      nodeGs.once(topic, shouldNotHappen)
-      nodeFs.on(topic, receivedMsg)
-
-      function receivedMsg (msg) {
-        expect(msg.data.toString()).to.equal('banana ' + counter)
-        expect(msg.from).to.be.eql(nodeGs.peerId.toB58String())
-        expect(msg.seqno).to.be.a('Uint8Array')
-        expect(msg.topicIDs).to.be.eql([topic])
-
-        if (++counter === 10) {
-          nodeFs.removeListener(topic, receivedMsg)
-          nodeGs.removeListener(topic, shouldNotHappen)
-          done()
-        }
-      }
-
-      times(10, (index) => nodeGs.publish(topic, uint8ArrayFromString('banana ' + index)))
-    })
-
-    it('Publish 10 msg to a topic as array', (done) => {
-      let counter = 0
-
-      const shouldNotHappen = () => {
-        done(new Error('Should not be here'))
-      }
-
-      nodeGs.once(topic, shouldNotHappen)
-
-      nodeFs.on(topic, receivedMsg)
-
-      function receivedMsg (msg) {
-        expect(msg.data.toString()).to.equal('banana ' + counter)
-        expect(msg.from).to.be.eql(nodeGs.peerId.toB58String())
-        expect(msg.seqno).to.be.a('Uint8Array')
-        expect(msg.topicIDs).to.be.eql([topic])
-
-        if (++counter === 10) {
-          nodeFs.removeListener(topic, receivedMsg)
-          nodeGs.removeListener(topic, shouldNotHappen)
-          done()
-        }
-      }
-
-      const msgs = []
-      times(10, (index) => msgs.push(uint8ArrayFromString('banana ' + index)))
-      msgs.forEach(msg => nodeGs.publish(topic, msg))
-    })
   })
 
   describe('publish after unsubscribe', () => {


### PR DESCRIPTION
Updates libp2p interfaces and floodsub

Removed floodsub uneeded tests with multiple messages as they are included in the interface for floodsub