### PR TITLE
Add message signing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Options is an optional object with the following key-value pairs:
 * **`floodPublish`**: boolean identifying if self-published messages should be sent to all peers, (defaults to **true**).
 * **`doPX`**: boolean identifying whether PX is enabled; this should be enabled in bootstrappers and other well connected/trusted nodes (defaults to **false**).
 * **`msgIdFn`**: a function with signature `(message) => string` defining the message id given a message, used internally to deduplicate gossip (defaults to `(message) => message.from + message.seqno.toString('hex')`)
+* **`signMessages`**: boolean identifying if we want to sign outgoing messages or not
+* **`strictSigning`**: boolean identifying if message signing is required for incoming messages or not
 * **`messageCache`**: optional, a customized `MessageCache` instance, see the implementation for the interface.
 * **`scoreParams`**: optional, a customized peer score parameters Object.
 * **`scoreThresholds`**: optional, a customized peer score thresholds Object.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Options is an optional object with the following key-value pairs:
 * **`floodPublish`**: boolean identifying if self-published messages should be sent to all peers, (defaults to **true**).
 * **`doPX`**: boolean identifying whether PX is enabled; this should be enabled in bootstrappers and other well connected/trusted nodes (defaults to **false**).
 * **`msgIdFn`**: a function with signature `(message) => string` defining the message id given a message, used internally to deduplicate gossip (defaults to `(message) => message.from + message.seqno.toString('hex')`)
-* **`signMessages`**: boolean identifying if we want to sign outgoing messages or not
-* **`strictSigning`**: boolean identifying if message signing is required for incoming messages or not
+* **`signMessages`**: boolean identifying if we want to sign outgoing messages or not (default: `true`)
+* **`strictSigning`**: boolean identifying if message signing is required for incoming messages or not (default: `true`)
 * **`messageCache`**: optional, a customized `MessageCache` instance, see the implementation for the interface.
 * **`scoreParams`**: optional, a customized peer score parameters Object.
 * **`scoreThresholds`**: optional, a customized peer score thresholds Object.

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -113,8 +113,8 @@ class Gossipsub extends Pubsub {
    * @param {bool} [options.doPX] whether PX is enabled; this should be enabled in bootstrappers and other well connected/trusted nodes. defaults to false
    * @param {function} [options.msgIdFn] override the default message id function
    * @param {Object} [options.messageCache] override the default MessageCache
-   * @param {bool} [options.signMessages] if we want to sign outgoing messages or not
-   * @param {bool} [options.strictSigning] if message signing is required for incoming messages or not
+   * @param {bool} [options.signMessages] if we want to sign outgoing messages or not (default: true)
+   * @param {bool} [options.strictSigning] if message signing is required for incoming messages or not (default: true)
    * @param {Object} [options.scoreParams] peer score parameters
    * @param {Object} [options.scoreThresholds] peer score thresholds
    * @param {AddrInfo[]} [options.directPeers] peers with which we will maintain direct connections

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -32,6 +32,8 @@ interface GossipInputOptions {
   doPX: boolean
   msgIdFn: (msg: InMessage) => string
   messageCache: MessageCache
+  signMessages: boolean
+  strictSigning: boolean
   scoreParams: Partial<PeerScoreParams>
   scoreThresholds: Partial<PeerScoreThresholds>
   directPeers: AddrInfo[]
@@ -111,6 +113,8 @@ class Gossipsub extends Pubsub {
    * @param {bool} [options.doPX] whether PX is enabled; this should be enabled in bootstrappers and other well connected/trusted nodes. defaults to false
    * @param {function} [options.msgIdFn] override the default message id function
    * @param {Object} [options.messageCache] override the default MessageCache
+   * @param {bool} [options.signMessages] if we want to sign outgoing messages or not
+   * @param {bool} [options.strictSigning] if message signing is required for incoming messages or not
    * @param {Object} [options.scoreParams] peer score parameters
    * @param {Object} [options.scoreThresholds] peer score thresholds
    * @param {AddrInfo[]} [options.directPeers] peers with which we will maintain direct connections
@@ -133,6 +137,8 @@ class Gossipsub extends Pubsub {
       Dscore: constants.GossipsubDscore,
       Dout: constants.GossipsubDout,
       Dlazy: constants.GossipsubDlazy,
+      signMessages: true,
+      strictSigning: true,
       ...options,
       scoreParams: createPeerScoreParams(options.scoreParams),
       scoreThresholds: createPeerScoreThresholds(options.scoreThresholds)


### PR DESCRIPTION
## Goal
+ For eth2, we want to disable message signing options `{signMessages: false, strictSigning: false}`
+ libp2p-interface allows us to do that, refer to https://github.com/libp2p/js-libp2p-interfaces/blob/master/src/pubsub/index.js#L49