### PR TITLE
chore: use latest libp2p release

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "it-pair": "^1.0.0",
-    "libp2p": "next",
+    "libp2p": "^0.32.0",
     "libp2p-floodsub": "^0.27.0",
     "libp2p-interfaces-compliance-tests": "^1.0.1",
     "libp2p-mplex": "^0.10.3",

--- a/package.json
+++ b/package.json
@@ -48,14 +48,14 @@
     "peer-id": "^0.15.0",
     "protobufjs": "^6.11.2",
     "time-cache": "^0.3.0",
-    "uint8arrays": "^2.1.5"
+    "uint8arrays": "^3.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.3",
     "@types/mocha": "^8.2.2",
     "@typescript-eslint/eslint-plugin": "^3.0.2",
     "@typescript-eslint/parser": "^3.0.2",
-    "aegir": "^33.2.0",
+    "aegir": "^35.0.1",
     "benchmark": "^2.1.4",
     "buffer": "^6.0.3",
     "chai": "^4.2.0",

--- a/test/2-nodes.spec.js
+++ b/test/2-nodes.spec.js
@@ -5,7 +5,7 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 chai.use(require('chai-spies'))
 const expect = chai.expect
-const uint8ArrayFromString = require('uint8arrays/from-string')
+const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
 const delay = require('delay')
 
 const { multicodec } = require('../src')

--- a/test/floodsub.spec.js
+++ b/test/floodsub.spec.js
@@ -6,7 +6,7 @@ chai.use(require('dirty-chai'))
 const expect = chai.expect
 
 const delay = require('delay')
-const uint8ArrayFromString = require('uint8arrays/from-string')
+const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
 
 const PeerId = require('peer-id')
 

--- a/test/gossip-incoming.spec.js
+++ b/test/gossip-incoming.spec.js
@@ -7,7 +7,7 @@ chai.use(require('chai-spies'))
 const expect = chai.expect
 
 const delay = require('delay')
-const uint8ArrayFromString = require('uint8arrays/from-string')
+const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
 
 const {
   createConnectedGossipsubs,

--- a/test/message-cache.spec.js
+++ b/test/message-cache.spec.js
@@ -18,7 +18,7 @@ describe('Testing Message Cache Operations', () => {
   const messageCache = new MessageCache(3, 5, getMsgId)
   const testMessages = []
 
-  before(() => {
+  before(async () => {
     const makeTestMessage = (n) => {
       return {
         from: 'test',
@@ -33,7 +33,7 @@ describe('Testing Message Cache Operations', () => {
     }
 
     for (let i = 0; i < 10; i++) {
-      messageCache.put(testMessages[i])
+      await messageCache.put(testMessages[i])
     }
   })
 
@@ -55,10 +55,10 @@ describe('Testing Message Cache Operations', () => {
     }
   })
 
-  it('Shift message cache', () => {
+  it('Shift message cache', async () => {
     messageCache.shift()
     for (let i = 10; i < 20; i++) {
-      messageCache.put(testMessages[i])
+      await messageCache.put(testMessages[i])
     }
 
     for (let i = 0; i < 20; i++) {
@@ -82,22 +82,22 @@ describe('Testing Message Cache Operations', () => {
 
     messageCache.shift()
     for (let i = 20; i < 30; i++) {
-      messageCache.put(testMessages[i])
+      await messageCache.put(testMessages[i])
     }
 
     messageCache.shift()
     for (let i = 30; i < 40; i++) {
-      messageCache.put(testMessages[i])
+      await messageCache.put(testMessages[i])
     }
 
     messageCache.shift()
     for (let i = 40; i < 50; i++) {
-      messageCache.put(testMessages[i])
+      await messageCache.put(testMessages[i])
     }
 
     messageCache.shift()
     for (let i = 50; i < 60; i++) {
-      messageCache.put(testMessages[i])
+      await messageCache.put(testMessages[i])
     }
 
     expect(messageCache.msgs.size).to.equal(50)

--- a/test/message-cache.spec.js
+++ b/test/message-cache.spec.js
@@ -8,7 +8,7 @@ chai.use(dirtyChai)
 const chaiSpies = require('chai-spies')
 chai.use(chaiSpies)
 const expect = chai.expect
-const uint8ArrayFromString = require('uint8arrays/from-string')
+const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
 
 const { MessageCache } = require('../src/message-cache')
 const { utils } = require('libp2p-interfaces/src/pubsub')

--- a/test/peer-score.spec.js
+++ b/test/peer-score.spec.js
@@ -412,7 +412,7 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_REJECT)
+      await ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_REJECT)
     }
     ps._refreshScores()
     let aScore = ps.score(peerA)
@@ -441,7 +441,7 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_REJECT)
+      await ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_REJECT)
     }
     ps._refreshScores()
     let aScore = ps.score(peerA)
@@ -478,12 +478,12 @@ describe('PeerScore', () => {
     msg.receivedFrom = peerA
 
     // insert a record
-    ps.validateMessage(msg)
+    await ps.validateMessage(msg)
 
     // this should have no effect in the score, and subsequent duplicate messages should have no effect either
-    ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_IGNORE)
+    await ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_IGNORE)
     msg.receivedFrom = peerB
-    ps.duplicateMessage(msg)
+    await ps.duplicateMessage(msg)
 
     let aScore = ps.score(peerA)
     let bScore = ps.score(peerB)
@@ -498,12 +498,12 @@ describe('PeerScore', () => {
 
     // insert a new record in the message deliveries
     msg.receivedFrom = peerA
-    ps.validateMessage(msg)
+    await ps.validateMessage(msg)
 
     // and reject the message to make sure duplicates are also penalized
-    ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_REJECT)
+    await ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_REJECT)
     msg.receivedFrom = peerB
-    ps.duplicateMessage(msg)
+    await ps.duplicateMessage(msg)
 
     aScore = ps.score(peerA)
     bScore = ps.score(peerB)
@@ -518,13 +518,13 @@ describe('PeerScore', () => {
 
     // insert a new record in the message deliveries
     msg.receivedFrom = peerA
-    ps.validateMessage(msg)
+    await ps.validateMessage(msg)
 
     // and reject the message after a duplicate has arrived
     msg.receivedFrom = peerB
-    ps.duplicateMessage(msg)
+    await ps.duplicateMessage(msg)
     msg.receivedFrom = peerA
-    ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_REJECT)
+    await ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_REJECT)
 
     aScore = ps.score(peerA)
     bScore = ps.score(peerB)

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -413,7 +413,7 @@ class Gossipsub extends Pubsub {
     }
     this.seenCache.put(msgIdStr)
 
-    this.score.validateMessage(msg)
+    await this.score.validateMessage(msg)
     await super._processRpcMessage(msg)
   }
 

--- a/ts/interfaces.ts
+++ b/ts/interfaces.ts
@@ -7,4 +7,4 @@ export interface AddrInfo {
   addrs: Multiaddr[]
 }
 
-export type MessageIdFunction = (msg: InMessage) => Uint8Array;
+export type MessageIdFunction = (msg: InMessage) => Promise<Uint8Array> | Uint8Array;

--- a/ts/message-cache.ts
+++ b/ts/message-cache.ts
@@ -52,10 +52,10 @@ export class MessageCache {
    * Adds a message to the current window and the cache
    *
    * @param {RPC.Message} msg
-   * @returns {void}
+   * @returns {Promise<void>}
    */
-  put (msg: InMessage): void {
-    const msgID = this.getMsgId(msg)
+  async put (msg: InMessage): Promise<void> {
+    const msgID = await this.getMsgId(msg)
     const msgIdStr = messageIdToString(msgID)
     this.msgs.set(msgIdStr, msg)
     this.history[0].push({ msgID, topics: msg.topicIDs })
@@ -64,9 +64,9 @@ export class MessageCache {
   /**
    * Get message id of message.
    * @param {RPC.Message} msg
-   * @returns {Uint8Array}
+   * @returns {Promise<Uint8Array> | Uint8Array}
    */
-  getMsgId (msg: InMessage): Uint8Array {
+  getMsgId (msg: InMessage): Promise<Uint8Array> | Uint8Array {
     return this.msgIdFn(msg)
   }
 

--- a/ts/score/peer-score.ts
+++ b/ts/score/peer-score.ts
@@ -286,21 +286,21 @@ export class PeerScore {
 
   /**
    * @param {InMessage} message
-   * @returns {void}
+   * @returns {Promise<void>}
    */
-  validateMessage (message: InMessage): void {
-    this.deliveryRecords.ensureRecord(this.msgId(message))
+  async validateMessage (message: InMessage): Promise<void> {
+    this.deliveryRecords.ensureRecord(await this.msgId(message))
   }
 
   /**
    * @param {InMessage} message
-   * @returns {void}
+   * @returns {Promise<void>}
    */
-  deliverMessage (message: InMessage): void {
+  async deliverMessage (message: InMessage): Promise<void> {
     const id = message.receivedFrom
     this._markFirstMessageDelivery(id, message)
 
-    const drec = this.deliveryRecords.ensureRecord(this.msgId(message))
+    const drec = this.deliveryRecords.ensureRecord(await this.msgId(message))
     const now = Date.now()
 
     // defensive check that this is the first delivery trace -- delivery status should be unknown
@@ -327,9 +327,9 @@ export class PeerScore {
   /**
    * @param {InMessage} message
    * @param {string} reason
-   * @returns {void}
+   * @returns {Promise<void>}
    */
-  rejectMessage (message: InMessage, reason: string): void {
+  async rejectMessage (message: InMessage, reason: string): Promise<void> {
     const id = message.receivedFrom
     switch (reason) {
       case ERR_MISSING_SIGNATURE:
@@ -338,7 +338,7 @@ export class PeerScore {
         return
     }
 
-    const drec = this.deliveryRecords.ensureRecord(this.msgId(message))
+    const drec = this.deliveryRecords.ensureRecord(await this.msgId(message))
 
     // defensive check that this is the first rejection -- delivery status should be unknown
     if (drec.status !== DeliveryRecordStatus.unknown) {
@@ -367,11 +367,11 @@ export class PeerScore {
 
   /**
    * @param {InMessage} message
-   * @returns {void}
+   * @returns {Promise<void>}
    */
-  duplicateMessage (message: InMessage): void {
+  async duplicateMessage (message: InMessage): Promise<void> {
     const id = message.receivedFrom
-    const drec = this.deliveryRecords.ensureRecord(this.msgId(message))
+    const drec = this.deliveryRecords.ensureRecord(await this.msgId(message))
 
     if (drec.peers.has(id)) {
       // we have already seen this duplicate

--- a/ts/tracer.ts
+++ b/ts/tracer.ts
@@ -82,10 +82,10 @@ export class IWantTracer {
   /**
    * Someone delivered a message, stop tracking promises for it
    * @param {InMessage} msg
-   * @returns {void}
+   * @returns {Promise<void>}
    */
-  deliverMessage (msg: InMessage): void {
-    const msgId = this.getMsgId(msg)
+  async deliverMessage (msg: InMessage): Promise<void> {
+    const msgId = await this.getMsgId(msg)
     const msgIdStr = messageIdToString(msgId)
     this.promises.delete(msgIdStr)
   }
@@ -95,16 +95,16 @@ export class IWantTracer {
    * unless its an obviously invalid message.
    * @param {InMessage} msg
    * @param {string} reason
-   * @returns {void}
+   * @returns {Promise<void>}
    */
-  rejectMessage (msg: InMessage, reason: string): void {
+  async rejectMessage (msg: InMessage, reason: string): Promise<void> {
     switch (reason) {
       case ERR_INVALID_SIGNATURE:
       case ERR_MISSING_SIGNATURE:
         return
     }
 
-    const msgId = this.getMsgId(msg)
+    const msgId = await this.getMsgId(msg)
     const msgIdStr = messageIdToString(msgId)
     this.promises.delete(msgIdStr)
   }

--- a/ts/utils/messageIdToString.ts
+++ b/ts/utils/messageIdToString.ts
@@ -1,7 +1,4 @@
-// remove ts-ignore once https://github.com/achingbrain/uint8arrays/pull/4 is merged
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import toString = require('uint8arrays/to-string')
+import { toString } from 'uint8arrays/to-string'
 
 export function messageIdToString (msgId: Uint8Array): string {
   return toString(msgId, 'base64')


### PR DESCRIPTION
It is important pointing out that `getMsgId` function might return a Promise per https://github.com/libp2p/js-libp2p-interfaces/blob/master/packages/interfaces/src/pubsub/index.js#L479 We were having issues in browser tests thanks to it, so I needed to make it accept promises too.

Also updates uint8arrays