### PR TITLE
feat: add more configuration options

### DIFF
--- a/ts/constants.ts
+++ b/ts/constants.ts
@@ -211,6 +211,11 @@ export const GossipsubMaxIHaveMessages = 10
  */
 export const GossipsubIWantFollowupTime = 3 * second
 
+/**
+ * Time in milliseconds to keep message ids in the seen cache
+ */
+export const GossipsubSeenTTL = 30 * second
+
 export const TimeCacheDuration = 120 * 1000
 
 export const ERR_TOPIC_VALIDATOR_REJECT = 'ERR_TOPIC_VALIDATOR_REJECT'

--- a/ts/heartbeat.ts
+++ b/ts/heartbeat.ts
@@ -29,7 +29,7 @@ export class Heartbeat {
 
     const timeout = setTimeout(() => {
       heartbeat()
-      this._heartbeatTimer!.runPeriodically(heartbeat, constants.GossipsubHeartbeatInterval)
+      this._heartbeatTimer!.runPeriodically(heartbeat, this.gossipsub._options.heartbeatInterval)
     }, constants.GossipsubHeartbeatInitialDelay)
 
     this._heartbeatTimer = {
@@ -69,7 +69,8 @@ export class Heartbeat {
       Dlo,
       Dhi,
       Dscore,
-      Dout
+      Dout,
+      fanoutTTL
     } = this.gossipsub._options
     this.gossipsub.heartbeatTicks++
 
@@ -285,7 +286,7 @@ export class Heartbeat {
     // expire fanout for topics we haven't published to in a while
     const now = this.gossipsub._now()
     this.gossipsub.lastpub.forEach((lastpb, topic) => {
-      if ((lastpb + constants.GossipsubFanoutTTL) < now) {
+      if ((lastpb + fanoutTTL) < now) {
         this.gossipsub.fanout.delete(topic)
         this.gossipsub.lastpub.delete(topic)
       }


### PR DESCRIPTION
There are many options currently set by constants.
This is limiting when applications want to override these for
application-specific networks.

Several interesting options are now overridable via the constructor:

- heartbeatInterval
- fanoutTTL
- mcacheLength
- mcacheGossip
- seenTTL

These options are optional with fallback values defaulting to the prior "constant" values.