### PR TITLE
Fix hearbeat tick handler rounding issue

### DIFF
--- a/ts/heartbeat.ts
+++ b/ts/heartbeat.ts
@@ -257,7 +257,7 @@ export class Heartbeat {
         // now compute the median peer score in the mesh
         const peersList = Array.from(peers)
           .sort((a, b) => getScore(a) - getScore(b))
-        const medianIndex = peers.size / 2
+        const medianIndex = Math.floor(peers.size / 2)
         const medianScore = getScore(peersList[medianIndex])
 
         // if the median score is below the threshold, select a better peer (if any) and GRAFT


### PR DESCRIPTION
**Motivation**
+ This fix the issue in the heartbeat when we want to find new peers better than the median score
+ To get the index in the middle of the sorted list, we want `Math.floor()`