### PR TITLE
Cache peer score

### DIFF
--- a/test/accept-from.spec.js
+++ b/test/accept-from.spec.js
@@ -1,0 +1,79 @@
+const {expect} = require('chai')
+const sinon = require('sinon')
+const {PeerScore} = require('../src/score')
+const Gossipsub = require('../src')
+const {
+  createPeer,
+} = require('./utils')
+
+describe('Gossipsub acceptFrom', () => {
+  let gossipsub
+  const sandbox = sinon.createSandbox()
+  let scoreStub
+
+  beforeEach(async () => {
+    sandbox.useFakeTimers()
+    gossipsub = new Gossipsub(await createPeer({ started: false }), { emitSelf: true })
+    scoreStub = sandbox.createStubInstance(PeerScore)
+    gossipsub.score = scoreStub
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it('should only white list peer with positive score', () => {
+    scoreStub.score.withArgs("peerA").returns(1000)
+    gossipsub._acceptFrom("peerA")
+    // 1st time, we have to compute score
+    expect(scoreStub.score.withArgs("peerA").calledOnce).to.be.true
+    // 2nd time, use a cached score since it's white listed
+    gossipsub._acceptFrom("peerA")
+    expect(scoreStub.score.withArgs("peerA").calledOnce).to.be.true
+  })
+
+  it('should recompute score after 1s', () => {
+    scoreStub.score.returns(1000)
+    gossipsub._acceptFrom("peerA")
+    // 1st time, we have to compute score
+    expect(scoreStub.score.withArgs("peerA").calledOnce).to.be.true
+    gossipsub._acceptFrom("peerA")
+    expect(scoreStub.score.withArgs("peerA").calledOnce).to.be.true
+
+    // after 1s
+    sandbox.clock.tick(1001)
+
+    gossipsub._acceptFrom("peerA")
+    expect(scoreStub.score.withArgs("peerA").calledTwice).to.be.true
+  })
+
+  it('should recompute score after max messages accepted', () => {
+    scoreStub.score.returns(1000)
+    gossipsub._acceptFrom("peerA")
+    // 1st time, we have to compute score
+    expect(scoreStub.score.withArgs("peerA").calledOnce).to.be.true
+
+    for (let i = 0; i < 128; i++) {
+      gossipsub._acceptFrom("peerA")
+    }
+    expect(scoreStub.score.withArgs("peerA").calledOnce).to.be.true
+
+    // max messages reached
+    gossipsub._acceptFrom("peerA")
+    expect(scoreStub.score.withArgs("peerA").calledTwice).to.be.true
+  })
+
+  it('should NOT white list peer with negative score', () => {
+    // peerB is not white listed since score is negative
+    scoreStub.score.withArgs("peerB").returns(-1)
+    gossipsub._acceptFrom("peerB")
+    // 1st time, we have to compute score
+    expect(scoreStub.score.withArgs("peerB").calledOnce).to.be.true
+    // 2nd time, still have to compute score since it's NOT white listed
+    gossipsub._acceptFrom("peerB")
+    expect(scoreStub.score.withArgs("peerB").calledTwice).to.be.true
+  })
+
+
+
+})

--- a/test/accept-from.spec.js
+++ b/test/accept-from.spec.js
@@ -8,10 +8,11 @@ const {
 
 describe('Gossipsub acceptFrom', () => {
   let gossipsub
-  const sandbox = sinon.createSandbox()
+  let sandbox
   let scoreStub
 
   beforeEach(async () => {
+    sandbox = sinon.createSandbox()
     sandbox.useFakeTimers()
     gossipsub = new Gossipsub(await createPeer({ started: false }), { emitSelf: true })
     scoreStub = sandbox.createStubInstance(PeerScore)

--- a/test/peer-score.spec.js
+++ b/test/peer-score.spec.js
@@ -682,7 +682,8 @@ describe('PeerScore score cache', function () {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
-    sandbox.useFakeTimers()
+    const now = Date.now()
+    sandbox.useFakeTimers(now)
     computeStoreStub = sandbox.stub(computeScoreModule, 'computeScore')
   })
 

--- a/test/peer-score.spec.js
+++ b/test/peer-score.spec.js
@@ -1,8 +1,10 @@
+const sinon = require('sinon')
 const { expect } = require('chai')
 const PeerId = require('peer-id')
 const delay = require('delay')
 
 const { PeerScore, createPeerScoreParams, createTopicScoreParams } = require('../src/score')
+const computeScoreModule = require('../src/score/compute-score')
 const { ERR_TOPIC_VALIDATOR_IGNORE, ERR_TOPIC_VALIDATOR_REJECT } = require('../src/constants')
 const { makeTestMessage, getMsgId } = require('./utils')
 
@@ -642,7 +644,6 @@ describe('PeerScore', () => {
     const ps = new PeerScore(params, connectionManager, getMsgId)
     ps.addPeer(peerA)
     ps.graft(peerA, mytopic)
-    
     // score should equal -1000 (app-specific score)
     const expected = -1000
     ps._refreshScores()
@@ -664,4 +665,71 @@ describe('PeerScore', () => {
     aScore = ps.score(peerA)
     expect(aScore).to.equal(0)
   })
+})
+
+describe('PeerScore score cache', function () {
+  let ps2
+  let peerA
+  const sandbox = sinon.createSandbox()
+  let computeStoreStub
+  const params = createPeerScoreParams({
+    appSpecificScore: () => -1000,
+    appSpecificWeight: 1,
+    retainScore: 800,
+    decayInterval: 1000,
+    topics: {a: {topicWeight: 10}}
+  })
+
+  beforeEach(async () => {
+    sandbox.useFakeTimers()
+    peerA = (await PeerId.create({keyType: 'secp256k1'})).toB58String()
+    computeStoreStub = sandbox.stub(computeScoreModule, 'computeScore')
+    ps2 = new PeerScore(params, connectionManager, getMsgId)
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it('should compute first time', function () {
+    computeStoreStub.returns(10)
+    ps2.addPeer(peerA)
+    expect(computeStoreStub.calledOnce).to.be.false
+    ps2.score(peerA)
+    expect(computeStoreStub.calledOnce).to.be.true
+    // this time peerA score is cached
+    ps2.score(peerA)
+    expect(computeStoreStub.calledOnce).to.be.true
+  })
+
+  const testCases = [
+    {name: 'decayInterval timeout', fun: () => sandbox.clock.tick(params.decayInterval)},
+    {name: '_refreshScores', fun: () => ps2._refreshScores()},
+    {name: 'addPenalty', fun: () => ps2.addPenalty(peerA, 10)},
+    {name: 'graft', fun: () => ps2.graft(peerA, 'a')},
+    {name: 'prune', fun: () => ps2.prune(peerA, 'a')},
+    {name: '_markInvalidMessageDelivery', fun: () => ps2._markInvalidMessageDelivery(peerA, {topicIDs: ['a']})},
+    {name: '_markFirstMessageDelivery', fun: () => ps2._markFirstMessageDelivery(peerA, {topicIDs: ['a']})},
+    {name: '_markDuplicateMessageDelivery', fun: () => ps2._markDuplicateMessageDelivery(peerA, {topicIDs: ['a']})},
+    {name: '_setIPs', fun: () => ps2._setIPs(peerA, [], ['127.0.0.1'])},
+    {name: '_removeIPs', fun: () => ps2._removeIPs(peerA, ['127.0.0.1'])},
+    {name: '_updateIPs', fun: () => ps2._updateIPs()},
+  ]
+
+  for (const {name, fun} of testCases) {
+    it(`should invalidate the cache after ${name}`, function () {
+      computeStoreStub.returns(10)
+      ps2.addPeer(peerA)
+      ps2.score(peerA)
+      expect(computeStoreStub.calledOnce).to.be.true
+      // the score is cached
+      ps2.score(peerA)
+      expect(computeStoreStub.calledOnce).to.be.true
+      // invalidate the cache
+      fun()
+      // should not use the cache
+      ps2.score(peerA)
+      expect(computeStoreStub.calledTwice).to.be.true
+    })
+  }
 })

--- a/test/peer-score.spec.js
+++ b/test/peer-score.spec.js
@@ -668,9 +668,8 @@ describe('PeerScore', () => {
 })
 
 describe('PeerScore score cache', function () {
-  let ps2
-  let peerA
-  const sandbox = sinon.createSandbox()
+  const peerA = '16Uiu2HAmMkH6ZLen2tbhiuNCTZLLvrZaDgufNdT5MPjtC9Hr9YNG'
+  let sandbox
   let computeStoreStub
   const params = createPeerScoreParams({
     appSpecificScore: () => -1000,
@@ -679,12 +678,12 @@ describe('PeerScore score cache', function () {
     decayInterval: 1000,
     topics: {a: {topicWeight: 10}}
   })
+  const ps2 = new PeerScore(params, connectionManager, getMsgId)
 
-  beforeEach(async () => {
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
     sandbox.useFakeTimers()
-    peerA = (await PeerId.create({keyType: 'secp256k1'})).toB58String()
     computeStoreStub = sandbox.stub(computeScoreModule, 'computeScore')
-    ps2 = new PeerScore(params, connectionManager, getMsgId)
   })
 
   afterEach(() => {

--- a/ts/constants.ts
+++ b/ts/constants.ts
@@ -220,3 +220,21 @@ export const TimeCacheDuration = 120 * 1000
 
 export const ERR_TOPIC_VALIDATOR_REJECT = 'ERR_TOPIC_VALIDATOR_REJECT'
 export const ERR_TOPIC_VALIDATOR_IGNORE = 'ERR_TOPIC_VALIDATOR_IGNORE'
+
+/**
+ * If peer score is better than this, we accept messages from this peer
+ * within ACCEPT_FROM_WHITE_LIST_DURATION_MS from the last time computing score.
+ **/
+export const ACCEPT_FROM_WHITE_LIST_THRESHOLD_SCORE = 0
+
+/**
+ * If peer score >= ACCEPT_FROM_WHITE_LIST_THRESHOLD_SCORE, accept up to this
+ * number of messages from that peer.
+ */
+export const ACCEPT_FROM_WHITE_LIST_MAX_MESSAGES = 128
+
+/**
+ * If peer score >= ACCEPT_FROM_WHITE_LIST_THRESHOLD_SCORE, accept messages from
+ * this peer up to this time duration.
+ */
+export const ACCEPT_FROM_WHITE_LIST_DURATION_MS = 1000

--- a/ts/constants.ts
+++ b/ts/constants.ts
@@ -223,18 +223,18 @@ export const ERR_TOPIC_VALIDATOR_IGNORE = 'ERR_TOPIC_VALIDATOR_IGNORE'
 
 /**
  * If peer score is better than this, we accept messages from this peer
- * within ACCEPT_FROM_WHITE_LIST_DURATION_MS from the last time computing score.
+ * within ACCEPT_FROM_WHITELIST_DURATION_MS from the last time computing score.
  **/
-export const ACCEPT_FROM_WHITE_LIST_THRESHOLD_SCORE = 0
+export const ACCEPT_FROM_WHITELIST_THRESHOLD_SCORE = 0
 
 /**
- * If peer score >= ACCEPT_FROM_WHITE_LIST_THRESHOLD_SCORE, accept up to this
+ * If peer score >= ACCEPT_FROM_WHITELIST_THRESHOLD_SCORE, accept up to this
  * number of messages from that peer.
  */
-export const ACCEPT_FROM_WHITE_LIST_MAX_MESSAGES = 128
+export const ACCEPT_FROM_WHITELIST_MAX_MESSAGES = 128
 
 /**
- * If peer score >= ACCEPT_FROM_WHITE_LIST_THRESHOLD_SCORE, accept messages from
+ * If peer score >= ACCEPT_FROM_WHITELIST_THRESHOLD_SCORE, accept messages from
  * this peer up to this time duration.
  */
-export const ACCEPT_FROM_WHITE_LIST_DURATION_MS = 1000
+export const ACCEPT_FROM_WHITELIST_DURATION_MS = 1000

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -17,7 +17,7 @@ import PeerId = require('peer-id')
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import Envelope = require('libp2p/src/record/envelope')
-import { ACCEPT_FROM_WHITE_LIST_DURATION_MS, ACCEPT_FROM_WHITE_LIST_MAX_MESSAGES, ACCEPT_FROM_WHITE_LIST_THRESHOLD_SCORE } from './constants'
+import { ACCEPT_FROM_WHITELIST_DURATION_MS, ACCEPT_FROM_WHITELIST_MAX_MESSAGES, ACCEPT_FROM_WHITELIST_THRESHOLD_SCORE } from './constants'
 
 interface GossipInputOptions {
   emitSelf: boolean
@@ -85,7 +85,7 @@ interface GossipOptions extends GossipInputOptions {
   scoreThresholds: PeerScoreThresholds
 }
 
-interface AcceptFromWhiteListEntry {
+interface AcceptFromWhitelistEntry {
   /** number of messages accepted since recomputing the peer's score */
   messagesAccepted: number
   /** have to recompute score after this time */
@@ -96,7 +96,7 @@ class Gossipsub extends Pubsub {
   peers: Map<string, PeerStreams>
   direct: Set<string>
   seenCache: SimpleTimeCache
-  acceptFromWhitelist: Map<string, AcceptFromWhiteListEntry>
+  acceptFromWhitelist: Map<string, AcceptFromWhitelistEntry>
   topics: Map<string, Set<string>>
   mesh: Map<string, Set<string>>
   fanout: Map<string, Set<string>>
@@ -194,7 +194,7 @@ class Gossipsub extends Pubsub {
     /**
      * Map of peer id and AcceptRequestWhileListEntry
      *
-     * @type {Map<string, AcceptFromWhiteListEntry}
+     * @type {Map<string, AcceptFromWhitelistEntry}
      */
     this.acceptFromWhitelist = new Map()
 
@@ -475,19 +475,19 @@ class Gossipsub extends Pubsub {
     const entry = this.acceptFromWhitelist.get(id)
 
     if (entry &&
-      entry.messagesAccepted < ACCEPT_FROM_WHITE_LIST_MAX_MESSAGES &&
+      entry.messagesAccepted < ACCEPT_FROM_WHITELIST_MAX_MESSAGES &&
       entry.acceptUntil >= now) {
       entry.messagesAccepted += 1
       return true
     }
 
     const score = this.score.score(id)
-    if (score >= ACCEPT_FROM_WHITE_LIST_THRESHOLD_SCORE) {
+    if (score >= ACCEPT_FROM_WHITELIST_THRESHOLD_SCORE) {
       // peer is unlikely to be able to drop its score to `graylistThreshold`
       // after 128 messages or 1s
       this.acceptFromWhitelist.set(id, {
         messagesAccepted: 0,
-        acceptUntil: now + ACCEPT_FROM_WHITE_LIST_DURATION_MS
+        acceptUntil: now + ACCEPT_FROM_WHITELIST_DURATION_MS
       })
     } else {
       this.acceptFromWhitelist.delete(id)

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -390,6 +390,8 @@ class Gossipsub extends Pubsub {
     // Remove from peer scoring
     this.score.removePeer(id)
 
+    this.acceptFromWhitelist.delete(id)
+
     return peerStreams
   }
 

--- a/ts/score/peer-score.ts
+++ b/ts/score/peer-score.ts
@@ -187,6 +187,7 @@ export class PeerScore {
     }
 
     const score = computeScore(id, pstats, this.params, this.peerIPs)
+    // decayInterval is used to refresh score so we don't want to cache more than that
     this.scoreCacheUntil.set(id, now + this.params.decayInterval)
     this.scoreCache.set(id, score)
     return score

--- a/ts/score/peer-score.ts
+++ b/ts/score/peer-score.ts
@@ -30,6 +30,9 @@ export class PeerScore {
    * IP colocation tracking; maps IP => set of peers.
    */
   peerIPs: Map<string, Set<string>>
+  /**
+   * Cache score up to decayInterval if topic stats are unchanged.
+   */
   scoreCache: Map<string, number>
   /**
    * Flag to mark a peer score cache valid or not.

--- a/ts/score/peer-score.ts
+++ b/ts/score/peer-score.ts
@@ -17,6 +17,13 @@ const {
 
 const log = debug('libp2p:gossipsub:score')
 
+interface ScoreCacheEntry {
+  /** The cached score, null if not cached */
+  score: number | null
+  /** Unix timestamp in miliseconds, the time after which the cached score for a peer is no longer valid */
+  cacheUntil: number
+}
+
 export class PeerScore {
   /**
    * The score parameters
@@ -33,11 +40,7 @@ export class PeerScore {
   /**
    * Cache score up to decayInterval if topic stats are unchanged.
    */
-  scoreCache: Map<string, number>
-  /**
-   * The time after which the cached score for a peer is no longer valid.
-   */
-  scoreCacheUntil: Map<string, number>
+  scoreCache: Map<string, ScoreCacheEntry>
   /**
    * Recent message delivery timing/participants
    */
@@ -56,7 +59,6 @@ export class PeerScore {
     this.peerStats = new Map()
     this.peerIPs = new Map()
     this.scoreCache = new Map()
-    this.scoreCacheUntil = new Map()
     this.deliveryRecords = new MessageDeliveries()
     this.msgId = msgId
   }
@@ -164,7 +166,7 @@ export class PeerScore {
         pstats.behaviourPenalty = 0
       }
 
-      this.scoreCacheUntil.set(id, 0)
+      this.scoreCache.set(id, { score: null, cacheUntil: 0 })
     })
   }
 
@@ -180,17 +182,19 @@ export class PeerScore {
     }
 
     const now = Date.now()
-    const cacheUntil = this.scoreCacheUntil.get(id)
-    if (cacheUntil !== undefined && cacheUntil > now) {
-      const score = this.scoreCache.get(id)
-      if (score !== undefined) return score
+    let cacheEntry = this.scoreCache.get(id)
+    if (cacheEntry === undefined) {
+      cacheEntry = { score: null, cacheUntil: 0 }
+      this.scoreCache.set(id, cacheEntry)
     }
 
-    const score = computeScore(id, pstats, this.params, this.peerIPs)
+    const { score, cacheUntil } = cacheEntry
+    if (cacheUntil > now && score !== null) return score
+
+    cacheEntry.score = computeScore(id, pstats, this.params, this.peerIPs)
     // decayInterval is used to refresh score so we don't want to cache more than that
-    this.scoreCacheUntil.set(id, now + this.params.decayInterval)
-    this.scoreCache.set(id, score)
-    return score
+    cacheEntry.cacheUntil = now + this.params.decayInterval
+    return cacheEntry.score
   }
 
   /**
@@ -205,7 +209,7 @@ export class PeerScore {
       return
     }
     pstats.behaviourPenalty += penalty
-    this.scoreCacheUntil.set(id, 0)
+    this.scoreCache.set(id, { score: null, cacheUntil: 0 })
   }
 
   /**
@@ -246,7 +250,6 @@ export class PeerScore {
 
     // delete score cache
     this.scoreCache.delete(id)
-    this.scoreCacheUntil.delete(id)
 
     // furthermore, when we decide to retain the score, the firstMessageDelivery counters are
     // reset to 0 and mesh delivery penalties applied.
@@ -286,7 +289,7 @@ export class PeerScore {
     tstats.graftTime = Date.now()
     tstats.meshTime = 0
     tstats.meshMessageDeliveriesActive = false
-    this.scoreCacheUntil.set(id, 0)
+    this.scoreCache.set(id, { score: null, cacheUntil: 0 })
   }
 
   /**
@@ -312,7 +315,7 @@ export class PeerScore {
       tstats.meshFailurePenalty += deficit * deficit
     }
     tstats.inMesh = false
-    this.scoreCacheUntil.set(id, 0)
+    this.scoreCache.set(id, { score: null, cacheUntil: 0 })
   }
 
   /**
@@ -447,7 +450,7 @@ export class PeerScore {
 
       tstats.invalidMessageDeliveries += 1
     })
-    this.scoreCacheUntil.set(id, 0)
+    this.scoreCache.set(id, { score: null, cacheUntil: 0 })
   }
 
   /**
@@ -485,7 +488,7 @@ export class PeerScore {
         tstats.meshMessageDeliveries = cap
       }
     })
-    this.scoreCacheUntil.set(id, 0)
+    this.scoreCache.set(id, { score: null, cacheUntil: 0 })
   }
 
   /**
@@ -529,7 +532,7 @@ export class PeerScore {
         tstats.meshMessageDeliveries = cap
       }
     })
-    this.scoreCacheUntil.set(id, 0)
+    this.scoreCache.set(id, { score: null, cacheUntil: 0 })
   }
 
   /**
@@ -591,7 +594,7 @@ export class PeerScore {
       }
     }
 
-    this.scoreCacheUntil.set(id, 0)
+    this.scoreCache.set(id, { score: null, cacheUntil: 0 })
   }
 
   /**
@@ -613,7 +616,7 @@ export class PeerScore {
       }
     })
 
-    this.scoreCacheUntil.set(id, 0)
+    this.scoreCache.set(id, { score: null, cacheUntil: 0 })
   }
 
   /**
@@ -625,7 +628,7 @@ export class PeerScore {
       const newIPs = this._getIPs(id)
       this._setIPs(id, newIPs, pstats.ips)
       pstats.ips = newIPs
-      this.scoreCacheUntil.set(id, 0)
+      this.scoreCache.set(id, { score: null, cacheUntil: 0 })
     })
   }
 }


### PR DESCRIPTION
**Motivation**
+ In lodestar, it takes 4% of cpu time just to compute peer score

**Description**
+ Cache peer score if topic stat & peer stat are unchanged for maximum `decayInterval` time period
+ Main consumer of `computeScore()` is `acceptFrom()` function which is called per incoming message. If peer score >= 0 we allow up to 128 messages and 1s not to compute score (this is safe enough considering `grayListThreshold=-16000`
+ Closes #169

Thanks Teku for the work https://github.com/libp2p/jvm-libp2p/pull/184