### PR TITLE
Fast messsage id cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ### Features
 
-* Support fast message id cache via fastMsgIdFn option
-* Application should implement an extra getCachedMsgIdStr() api
-* New getCanonicalMsgIdStr() api to get canonical message id from application cache, or fast cache or compute it
-* This change is backward compatible
+* Add optional fast message id cache via the `fastMsgIdFn` option
+  * In certain applications, computing the message id (`getMsgId`) is relatively expensive. This addition allows for an application to optionally define a "fast" message id function that will be used internally.
+* Add optional cached message id function via `getCachedMsgIdStr` method override
+  * Applications can maintain their own cache of message ids
 
 ## [0.12.1](https://github.com/ChainSafe/js-libp2p-gossipsub/compare/v0.12.0...v0.12.1) (2021-12-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Features
+
+* Add fast message id cache
+* Application should implement an extra getCachedMsgIdStr() api
+* New getCanonicalMsgIdStr() api to get canonical message id from application cache, or fast cache or compute it.
+
 ## [0.12.1](https://github.com/ChainSafe/js-libp2p-gossipsub/compare/v0.12.0...v0.12.1) (2021-12-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ### Features
 
-* Add fast message id cache
+* Support fast message id cache via fastMsgIdFn option
 * Application should implement an extra getCachedMsgIdStr() api
-* New getCanonicalMsgIdStr() api to get canonical message id from application cache, or fast cache or compute it.
+* New getCanonicalMsgIdStr() api to get canonical message id from application cache, or fast cache or compute it
+* This change is backward compatible
 
 ## [0.12.1](https://github.com/ChainSafe/js-libp2p-gossipsub/compare/v0.12.0...v0.12.1) (2021-12-03)
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "homepage": "https://github.com/ChainSafe/js-libp2p-gossipsub#readme",
   "dependencies": {
     "@types/debug": "^4.1.7",
-    "@chainsafe/as-sha256": "^0.2.4",
     "debug": "^4.3.1",
     "denque": "^1.5.0",
     "err-code": "^3.0.1",
@@ -53,6 +52,7 @@
   },
   "devDependencies": {
     "@chainsafe/libp2p-noise": "^4.1.1",
+    "@chainsafe/as-sha256": "^0.2.4",
     "@types/chai": "^4.2.3",
     "@types/mocha": "^8.2.2",
     "@typescript-eslint/eslint-plugin": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "homepage": "https://github.com/ChainSafe/js-libp2p-gossipsub#readme",
   "dependencies": {
     "@types/debug": "^4.1.7",
+    "@chainsafe/as-sha256": "^0.2.4",
     "debug": "^4.3.1",
     "denque": "^1.5.0",
     "err-code": "^3.0.1",

--- a/test/2-nodes.spec.js
+++ b/test/2-nodes.spec.js
@@ -152,7 +152,7 @@ describe('2 nodes', () => {
       nodes[0].on(topic, receivedMsg)
 
       function receivedMsg (msg) {
-        expect(msg.data.toString()).to.equal('banana')
+        expect(msg.data.toString().startsWith('banana')).to.be.true
         expect(msg.from).to.be.eql(nodes[1].peerId.toB58String())
         expect(msg.seqno).to.be.a('Uint8Array')
         expect(msg.topicIDs).to.be.eql([topic])
@@ -164,8 +164,8 @@ describe('2 nodes', () => {
         }
       }
 
-      Array.from({ length: 10 }).forEach(() => {
-        nodes[1].publish(topic, uint8ArrayFromString('banana'))
+      Array.from({ length: 10 }).forEach((_, i) => {
+        nodes[1].publish(topic, uint8ArrayFromString('banana' + i))
       })
     })
   })

--- a/test/accept-from.spec.js
+++ b/test/accept-from.spec.js
@@ -1,6 +1,7 @@
 const {expect} = require('chai')
 const sinon = require('sinon')
 const Gossipsub = require('../src')
+const {fastMsgIdFn} = require('./utils/msgId')
 
 describe('Gossipsub acceptFrom', () => {
   let gossipsub
@@ -10,7 +11,7 @@ describe('Gossipsub acceptFrom', () => {
   beforeEach(async () => {
     sandbox = sinon.createSandbox()
     sandbox.useFakeTimers(Date.now())
-    gossipsub = new Gossipsub({}, { emitSelf: false })
+    gossipsub = new Gossipsub({}, { emitSelf: false, fastMsgIdFn })
     // stubbing PeerScore causes some pending issue in firefox browser environment
     // we can only spy it
     // using scoreSpy.withArgs("peerA").calledOnce causes the pending issue in firefox

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -6,7 +6,8 @@ const tests = require('libp2p-interfaces-compliance-tests/src/pubsub')
 const Gossipsub = require('../src')
 const { createPeers } = require('./utils/create-peer')
 
-describe('interface compliance', () => {
+describe('interface compliance', function () {
+  this.timeout(3000)
   let peers
   let pubsubNodes = []
 
@@ -17,6 +18,9 @@ describe('interface compliance', () => {
       peers.forEach((peer) => {
         const gossipsub = new Gossipsub(peer, {
           emitSelf: true,
+          // we don't want to cache anything, spec test sends duplicate messages and expect
+          // peer to receive all.
+          seenTTL: -1,
           ...options
         })
 

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -5,6 +5,7 @@ const tests = require('libp2p-interfaces-compliance-tests/src/pubsub')
 
 const Gossipsub = require('../src')
 const { createPeers } = require('./utils/create-peer')
+const { fastMsgIdFn } = require('./utils/msgId')
 
 describe('interface compliance', function () {
   this.timeout(3000)
@@ -18,6 +19,7 @@ describe('interface compliance', function () {
       peers.forEach((peer) => {
         const gossipsub = new Gossipsub(peer, {
           emitSelf: true,
+          fastMsgIdFn,
           // we don't want to cache anything, spec test sends duplicate messages and expect
           // peer to receive all.
           seenTTL: -1,

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -5,7 +5,6 @@ const tests = require('libp2p-interfaces-compliance-tests/src/pubsub')
 
 const Gossipsub = require('../src')
 const { createPeers } = require('./utils/create-peer')
-const { fastMsgIdFn } = require('./utils/msgId')
 
 describe('interface compliance', function () {
   this.timeout(3000)
@@ -19,7 +18,6 @@ describe('interface compliance', function () {
       peers.forEach((peer) => {
         const gossipsub = new Gossipsub(peer, {
           emitSelf: true,
-          fastMsgIdFn,
           // we don't want to cache anything, spec test sends duplicate messages and expect
           // peer to receive all.
           seenTTL: -1,

--- a/test/floodsub.spec.js
+++ b/test/floodsub.spec.js
@@ -17,8 +17,7 @@ const {
   expectSet,
   first,
   startNode,
-  stopNode,
-  fastMsgIdFn
+  stopNode
 } = require('./utils')
 
 describe('gossipsub fallbacks to floodsub', () => {
@@ -27,7 +26,7 @@ describe('gossipsub fallbacks to floodsub', () => {
     let nodeFs
 
     beforeEach(async () => {
-      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true, fastMsgIdFn })
+      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true })
       nodeFs = await createFloodsubNode(await createPeer({ peerId: await PeerId.create(), started: false }))
 
       await Promise.all([
@@ -57,7 +56,7 @@ describe('gossipsub fallbacks to floodsub', () => {
     let nodeFs
 
     before(async () => {
-      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: false, fastMsgIdFn })
+      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: false })
       nodeFs = await createFloodsubNode(await createPeer({ peerId: await PeerId.create(), started: false }))
 
       await Promise.all([
@@ -90,7 +89,7 @@ describe('gossipsub fallbacks to floodsub', () => {
     let nodeFs
 
     before(async () => {
-      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true, fastMsgIdFn })
+      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true })
       nodeFs = await createFloodsubNode(await createPeer({ peerId: await PeerId.create(), started: false }))
 
       await Promise.all([
@@ -141,7 +140,7 @@ describe('gossipsub fallbacks to floodsub', () => {
     const topic = 'Z'
 
     beforeEach(async () => {
-      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true, fastMsgIdFn })
+      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true })
       nodeFs = await createFloodsubNode(await createPeer({ peerId: await PeerId.create(), started: false }))
 
       await Promise.all([
@@ -204,7 +203,7 @@ describe('gossipsub fallbacks to floodsub', () => {
     const topic = 'Z'
 
     beforeEach(async () => {
-      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true, fastMsgIdFn })
+      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true })
       nodeFs = await createFloodsubNode(await createPeer({ peerId: await PeerId.create(), started: false }))
 
       await Promise.all([

--- a/test/floodsub.spec.js
+++ b/test/floodsub.spec.js
@@ -17,7 +17,8 @@ const {
   expectSet,
   first,
   startNode,
-  stopNode
+  stopNode,
+  fastMsgIdFn
 } = require('./utils')
 
 describe('gossipsub fallbacks to floodsub', () => {
@@ -26,7 +27,7 @@ describe('gossipsub fallbacks to floodsub', () => {
     let nodeFs
 
     beforeEach(async () => {
-      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true })
+      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true, fastMsgIdFn })
       nodeFs = await createFloodsubNode(await createPeer({ peerId: await PeerId.create(), started: false }))
 
       await Promise.all([
@@ -56,7 +57,7 @@ describe('gossipsub fallbacks to floodsub', () => {
     let nodeFs
 
     before(async () => {
-      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: false })
+      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: false, fastMsgIdFn })
       nodeFs = await createFloodsubNode(await createPeer({ peerId: await PeerId.create(), started: false }))
 
       await Promise.all([
@@ -89,7 +90,7 @@ describe('gossipsub fallbacks to floodsub', () => {
     let nodeFs
 
     before(async () => {
-      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true })
+      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true, fastMsgIdFn })
       nodeFs = await createFloodsubNode(await createPeer({ peerId: await PeerId.create(), started: false }))
 
       await Promise.all([
@@ -140,7 +141,7 @@ describe('gossipsub fallbacks to floodsub', () => {
     const topic = 'Z'
 
     beforeEach(async () => {
-      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true })
+      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true, fastMsgIdFn })
       nodeFs = await createFloodsubNode(await createPeer({ peerId: await PeerId.create(), started: false }))
 
       await Promise.all([
@@ -203,7 +204,7 @@ describe('gossipsub fallbacks to floodsub', () => {
     const topic = 'Z'
 
     beforeEach(async () => {
-      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true })
+      nodeGs = new Gossipsub(await createPeer({ started: false }), { fallbackToFloodsub: true, fastMsgIdFn })
       nodeFs = await createFloodsubNode(await createPeer({ peerId: await PeerId.create(), started: false }))
 
       await Promise.all([

--- a/test/go-gossipsub.js
+++ b/test/go-gossipsub.js
@@ -189,7 +189,7 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
 
     sendRecv = []
     for (let i = 0; i < 100; i++) {
-      const msg = uint8ArrayFromString(`${i} its not a flooooood ${i}`)
+      const msg = uint8ArrayFromString(`2nd - ${i} its not a flooooood ${i}`)
 
       const owner = 0
 
@@ -228,9 +228,9 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
     await Promise.all(psubs.map(ps => awaitEvents(ps, 'gossipsub:heartbeat', 2)))
 
     let sendRecv = []
-    const sendMessages = () => {
+    const sendMessages = (time) => {
       for (let i = 0; i < 100; i++) {
-        const msg = uint8ArrayFromString(`${i} its not a flooooood ${i}`)
+        const msg = uint8ArrayFromString(`${time} ${i} its not a flooooood ${i}`)
 
         const owner = 0
 
@@ -244,7 +244,7 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
         sendRecv.push(results)
       }
     }
-    sendMessages()
+    sendMessages(1)
     await Promise.all(sendRecv)
 
     psubs.slice(1).forEach(ps => ps.unsubscribe(topic))
@@ -258,7 +258,7 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
     await Promise.all(psubs.map(ps => awaitEvents(ps, 'gossipsub:heartbeat', 2)))
 
     sendRecv = []
-    sendMessages()
+    sendMessages(2)
     await Promise.all(sendRecv)
     await tearDownGossipsubs(psubs)
   })
@@ -891,7 +891,7 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
 
     sendRecv = []
     for (let i = 0; i < 3; i++) {
-      const msg = uint8ArrayFromString(`${i} its not a flooooood ${i}`)
+      const msg = uint8ArrayFromString(`2nd - ${i} its not a flooooood ${i}`)
       const owner = i
       const results = Promise.all(
         psubs
@@ -1035,7 +1035,8 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
 
     const msg = uint8ArrayFromString('its not a flooooood')
     await psubs[1].publish(topic, msg)
-    await psubs[2].publish(topic, msg)
+    const msg2 = uint8ArrayFromString('2nd - its not a flooooood')
+    await psubs[2].publish(topic, msg2)
 
     await Promise.all(psubs.map(ps => awaitEvents(ps, 'gossipsub:heartbeat', 2)))
 

--- a/test/go-gossipsub.js
+++ b/test/go-gossipsub.js
@@ -20,11 +20,12 @@ const {
   sparseConnect,
   denseConnect,
   stopNode,
-  createPeers,
-  expectSet,
   connectSome,
   connectGossipsub,
-  tearDownGossipsubs
+  expectSet,
+  fastMsgIdFn,
+  tearDownGossipsubs,
+  createPeers,
 } = require('./utils')
 
 EventEmitter.defaultMaxListeners = 100
@@ -639,7 +640,7 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
     const gsubs = libp2ps.slice(0, 20).map((libp2p) => {
       return new Gossipsub(
         libp2p,
-        { scoreParams: { IPColocationFactorThreshold: 20 } }
+        { scoreParams: { IPColocationFactorThreshold: 20 }, fastMsgIdFn }
       )
     })
     const fsubs = libp2ps.slice(20).map((libp2p) => {
@@ -831,7 +832,7 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
     const psubs =  [
       new Gossipsub(
         libp2ps[0],
-        { scoreParams: { IPColocationFactorThreshold: 20 } }
+        { scoreParams: { IPColocationFactorThreshold: 20 }, fastMsgIdFn }
       ),
       new Gossipsub(
         libp2ps[1],
@@ -840,7 +841,8 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
           directPeers: [{
             id: libp2ps[2].peerId,
             addrs: libp2ps[2].multiaddrs
-          }]
+          }],
+          fastMsgIdFn
         }
       ),
       new Gossipsub(
@@ -850,7 +852,8 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
           directPeers: [{
             id: libp2ps[1].peerId,
             addrs: libp2ps[1].multiaddrs
-          }]
+          }],
+          fastMsgIdFn
         }
       ),
     ]
@@ -962,7 +965,8 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
             gossipThreshold: -10,
             publishThreshold: -100,
             graylistThreshold: -1000
-          }
+          },
+          fastMsgIdFn
         }
       )
     )
@@ -1048,7 +1052,7 @@ describe("go-libp2p-pubsub gossipsub tests", function () {
   it("test gossipsub piggyback control", async function () {
     const libp2ps = await createPeers({ number: 2 })
     const otherId = libp2ps[1].peerId.toB58String()
-    const psub = new Gossipsub(libp2ps[0])
+    const psub = new Gossipsub(libp2ps[0], {fastMsgIdFn})
     await psub.start()
 
     const test1 = 'test1'

--- a/test/heartbeat.spec.js
+++ b/test/heartbeat.spec.js
@@ -8,15 +8,14 @@ const { GossipsubHeartbeatInterval } = require('../src/constants')
 const {
   createPeer,
   startNode,
-  stopNode,
-  fastMsgIdFn,
+  stopNode
 } = require('./utils')
 
 describe('heartbeat', () => {
   let gossipsub
 
   before(async () => {
-    gossipsub = new Gossipsub(await createPeer({ started: false }), { emitSelf: true, fastMsgIdFn })
+    gossipsub = new Gossipsub(await createPeer({ started: false }), { emitSelf: true })
     await startNode(gossipsub)
   })
 

--- a/test/heartbeat.spec.js
+++ b/test/heartbeat.spec.js
@@ -8,14 +8,15 @@ const { GossipsubHeartbeatInterval } = require('../src/constants')
 const {
   createPeer,
   startNode,
-  stopNode
+  stopNode,
+  fastMsgIdFn,
 } = require('./utils')
 
 describe('heartbeat', () => {
   let gossipsub
 
   before(async () => {
-    gossipsub = new Gossipsub(await createPeer({ started: false }), { emitSelf: true })
+    gossipsub = new Gossipsub(await createPeer({ started: false }), { emitSelf: true, fastMsgIdFn })
     await startNode(gossipsub)
   })
 

--- a/test/message-cache.spec.js
+++ b/test/message-cache.spec.js
@@ -8,6 +8,7 @@ chai.use(dirtyChai)
 const chaiSpies = require('chai-spies')
 chai.use(chaiSpies)
 const expect = chai.expect
+const { messageIdToString } = require('../src/utils/messageIdToString')
 const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
 
 const { MessageCache } = require('../src/message-cache')
@@ -15,7 +16,7 @@ const { utils } = require('libp2p-interfaces/src/pubsub')
 const { getMsgId } = require('./utils')
 
 describe('Testing Message Cache Operations', () => {
-  const messageCache = new MessageCache(3, 5, getMsgId)
+  const messageCache = new MessageCache(3, 5)
   const testMessages = []
 
   before(async () => {
@@ -33,7 +34,7 @@ describe('Testing Message Cache Operations', () => {
     }
 
     for (let i = 0; i < 10; i++) {
-      await messageCache.put(testMessages[i])
+      await messageCache.put(testMessages[i], messageIdToString(getMsgId(testMessages[i])))
     }
   })
 
@@ -58,7 +59,7 @@ describe('Testing Message Cache Operations', () => {
   it('Shift message cache', async () => {
     messageCache.shift()
     for (let i = 10; i < 20; i++) {
-      await messageCache.put(testMessages[i])
+      await messageCache.put(testMessages[i], messageIdToString(getMsgId(testMessages[i])))
     }
 
     for (let i = 0; i < 20; i++) {
@@ -82,22 +83,22 @@ describe('Testing Message Cache Operations', () => {
 
     messageCache.shift()
     for (let i = 20; i < 30; i++) {
-      await messageCache.put(testMessages[i])
+      await messageCache.put(testMessages[i], messageIdToString(getMsgId(testMessages[i])))
     }
 
     messageCache.shift()
     for (let i = 30; i < 40; i++) {
-      await messageCache.put(testMessages[i])
+      await messageCache.put(testMessages[i], messageIdToString(getMsgId(testMessages[i])))
     }
 
     messageCache.shift()
     for (let i = 40; i < 50; i++) {
-      await messageCache.put(testMessages[i])
+      await messageCache.put(testMessages[i], messageIdToString(getMsgId(testMessages[i])))
     }
 
     messageCache.shift()
     for (let i = 50; i < 60; i++) {
-      await messageCache.put(testMessages[i])
+      await messageCache.put(testMessages[i], messageIdToString(getMsgId(testMessages[i])))
     }
 
     expect(messageCache.msgs.size).to.equal(50)

--- a/test/peer-score.spec.js
+++ b/test/peer-score.spec.js
@@ -5,6 +5,7 @@ const delay = require('delay')
 
 const { PeerScore, createPeerScoreParams, createTopicScoreParams } = require('../src/score')
 const computeScoreModule = require('../src/score/compute-score')
+const { messageIdToString } = require('../src/utils/messageIdToString')
 const { ERR_TOPIC_VALIDATOR_IGNORE, ERR_TOPIC_VALIDATOR_REJECT } = require('../src/constants')
 const { makeTestMessage, getMsgId } = require('./utils')
 
@@ -101,8 +102,8 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      ps.validateMessage(msg)
-      ps.deliverMessage(msg)
+      ps.validateMessage(messageIdToString(getMsgId(msg)))
+      ps.deliverMessage(msg, messageIdToString(getMsgId(msg)))
     }
 
     ps._refreshScores()
@@ -141,8 +142,8 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      ps.validateMessage(msg)
-      ps.deliverMessage(msg)
+      ps.validateMessage(messageIdToString(getMsgId(msg)))
+      ps.deliverMessage(msg, messageIdToString(getMsgId(msg)))
     }
 
     ps._refreshScores()
@@ -181,8 +182,8 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      ps.validateMessage(msg)
-      ps.deliverMessage(msg)
+      ps.validateMessage(messageIdToString(getMsgId(msg)))
+      ps.deliverMessage(msg, messageIdToString(getMsgId(msg)))
     }
 
     ps._refreshScores()
@@ -227,7 +228,7 @@ describe('PeerScore', () => {
     const peerC = (await PeerId.create({keyType: 'secp256k1'})).toB58String()
     const peers = [peerA, peerB, peerC]
     // Peer score should start at 0
-    const ps = new PeerScore(params, connectionManager, getMsgId)
+    const ps = new PeerScore(params, connectionManager)
     peers.forEach(p => {
       ps.addPeer(p)
       ps.graft(p, mytopic)
@@ -250,16 +251,16 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      ps.validateMessage(msg)
-      ps.deliverMessage(msg)
+      ps.validateMessage(messageIdToString(getMsgId(msg)))
+      ps.deliverMessage(msg, messageIdToString(getMsgId(msg)))
 
       msg.receivedFrom = peerB
-      ps.duplicateMessage(msg)
+      ps.duplicateMessage(msg, messageIdToString(getMsgId(msg)))
 
       // deliver duplicate from peer C after the window
       await delay(tparams.meshMessageDeliveriesWindow + 5)
       msg.receivedFrom = peerC
-      ps.duplicateMessage(msg)
+      ps.duplicateMessage(msg, messageIdToString(getMsgId(msg)))
     }
     ps._refreshScores()
     const aScore = ps.score(peerA)
@@ -306,8 +307,8 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      ps.validateMessage(msg)
-      ps.deliverMessage(msg)
+      ps.validateMessage(messageIdToString(getMsgId(msg)))
+      ps.deliverMessage(msg, messageIdToString(getMsgId(msg)))
     }
     ps._refreshScores()
     let aScore = ps.score(peerA)
@@ -370,8 +371,8 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      ps.validateMessage(msg)
-      ps.deliverMessage(msg)
+      ps.validateMessage(messageIdToString(getMsgId(msg)))
+      ps.deliverMessage(msg, messageIdToString(getMsgId(msg)))
     }
     // peers A and B should both have zero scores, since the failure penalty hasn't been applied yet
     ps._refreshScores()
@@ -405,7 +406,7 @@ describe('PeerScore', () => {
       timeInMeshWeight: 0
     })
     const peerA = (await PeerId.create({keyType: 'secp256k1'})).toB58String()
-    const ps = new PeerScore(params, connectionManager, getMsgId)
+    const ps = new PeerScore(params, connectionManager)
     ps.addPeer(peerA)
     ps.graft(peerA, mytopic)
 
@@ -414,7 +415,7 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      await ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_REJECT)
+      await ps.rejectMessage(msg, messageIdToString(getMsgId(msg)), ERR_TOPIC_VALIDATOR_REJECT)
     }
     ps._refreshScores()
     let aScore = ps.score(peerA)
@@ -434,7 +435,7 @@ describe('PeerScore', () => {
       timeInMeshWeight: 0
     })
     const peerA = (await PeerId.create({keyType: 'secp256k1'})).toB58String()
-    const ps = new PeerScore(params, connectionManager, getMsgId)
+    const ps = new PeerScore(params, connectionManager)
     ps.addPeer(peerA)
     ps.graft(peerA, mytopic)
 
@@ -443,7 +444,7 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      await ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_REJECT)
+      await ps.rejectMessage(msg, messageIdToString(getMsgId(msg)), ERR_TOPIC_VALIDATOR_REJECT)
     }
     ps._refreshScores()
     let aScore = ps.score(peerA)
@@ -472,7 +473,7 @@ describe('PeerScore', () => {
     })
     const peerA = (await PeerId.create({keyType: 'secp256k1'})).toB58String()
     const peerB = (await PeerId.create({keyType: 'secp256k1'})).toB58String()
-    const ps = new PeerScore(params, connectionManager, getMsgId)
+    const ps = new PeerScore(params, connectionManager)
     ps.addPeer(peerA)
     ps.addPeer(peerB)
 
@@ -480,12 +481,12 @@ describe('PeerScore', () => {
     msg.receivedFrom = peerA
 
     // insert a record
-    await ps.validateMessage(msg)
+    await ps.validateMessage(messageIdToString(getMsgId(msg)))
 
     // this should have no effect in the score, and subsequent duplicate messages should have no effect either
-    await ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_IGNORE)
+    await ps.rejectMessage(msg, messageIdToString(getMsgId(msg)), ERR_TOPIC_VALIDATOR_IGNORE)
     msg.receivedFrom = peerB
-    await ps.duplicateMessage(msg)
+    await ps.duplicateMessage(msg, messageIdToString(getMsgId(msg)))
 
     let aScore = ps.score(peerA)
     let bScore = ps.score(peerB)
@@ -500,12 +501,12 @@ describe('PeerScore', () => {
 
     // insert a new record in the message deliveries
     msg.receivedFrom = peerA
-    await ps.validateMessage(msg)
+    await ps.validateMessage(messageIdToString(getMsgId(msg)))
 
     // and reject the message to make sure duplicates are also penalized
-    await ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_REJECT)
+    await ps.rejectMessage(msg, messageIdToString(getMsgId(msg)), ERR_TOPIC_VALIDATOR_REJECT)
     msg.receivedFrom = peerB
-    await ps.duplicateMessage(msg)
+    await ps.duplicateMessage(msg, messageIdToString(getMsgId(msg)))
 
     aScore = ps.score(peerA)
     bScore = ps.score(peerB)
@@ -520,13 +521,13 @@ describe('PeerScore', () => {
 
     // insert a new record in the message deliveries
     msg.receivedFrom = peerA
-    await ps.validateMessage(msg)
+    await ps.validateMessage(messageIdToString(getMsgId(msg)))
 
     // and reject the message after a duplicate has arrived
     msg.receivedFrom = peerB
-    await ps.duplicateMessage(msg)
+    await ps.duplicateMessage(msg, messageIdToString(getMsgId(msg)))
     msg.receivedFrom = peerA
-    await ps.rejectMessage(msg, ERR_TOPIC_VALIDATOR_REJECT)
+    await ps.rejectMessage(msg, messageIdToString(getMsgId(msg)), ERR_TOPIC_VALIDATOR_REJECT)
 
     aScore = ps.score(peerA)
     bScore = ps.score(peerB)

--- a/test/peer-score.spec.js
+++ b/test/peer-score.spec.js
@@ -5,9 +5,8 @@ const delay = require('delay')
 
 const { PeerScore, createPeerScoreParams, createTopicScoreParams } = require('../src/score')
 const computeScoreModule = require('../src/score/compute-score')
-const { messageIdToString } = require('../src/utils/messageIdToString')
 const { ERR_TOPIC_VALIDATOR_IGNORE, ERR_TOPIC_VALIDATOR_REJECT } = require('../src/constants')
-const { makeTestMessage, getMsgId } = require('./utils')
+const { makeTestMessage, getMsgId, getMsgIdStr } = require('./utils')
 
 const connectionManager = new Map()
 connectionManager.getAll = () => ([])
@@ -102,8 +101,8 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      ps.validateMessage(messageIdToString(getMsgId(msg)))
-      ps.deliverMessage(msg, messageIdToString(getMsgId(msg)))
+      ps.validateMessage(getMsgIdStr(msg))
+      ps.deliverMessage(msg, getMsgIdStr(msg))
     }
 
     ps._refreshScores()
@@ -142,8 +141,8 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      ps.validateMessage(messageIdToString(getMsgId(msg)))
-      ps.deliverMessage(msg, messageIdToString(getMsgId(msg)))
+      ps.validateMessage(getMsgIdStr(msg))
+      ps.deliverMessage(msg, getMsgIdStr(msg))
     }
 
     ps._refreshScores()
@@ -182,8 +181,8 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      ps.validateMessage(messageIdToString(getMsgId(msg)))
-      ps.deliverMessage(msg, messageIdToString(getMsgId(msg)))
+      ps.validateMessage(getMsgIdStr(msg))
+      ps.deliverMessage(msg, getMsgIdStr(msg))
     }
 
     ps._refreshScores()
@@ -251,16 +250,16 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      ps.validateMessage(messageIdToString(getMsgId(msg)))
-      ps.deliverMessage(msg, messageIdToString(getMsgId(msg)))
+      ps.validateMessage(getMsgIdStr(msg))
+      ps.deliverMessage(msg, getMsgIdStr(msg))
 
       msg.receivedFrom = peerB
-      ps.duplicateMessage(msg, messageIdToString(getMsgId(msg)))
+      ps.duplicateMessage(msg, getMsgIdStr(msg))
 
       // deliver duplicate from peer C after the window
       await delay(tparams.meshMessageDeliveriesWindow + 5)
       msg.receivedFrom = peerC
-      ps.duplicateMessage(msg, messageIdToString(getMsgId(msg)))
+      ps.duplicateMessage(msg, getMsgIdStr(msg))
     }
     ps._refreshScores()
     const aScore = ps.score(peerA)
@@ -307,8 +306,8 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      ps.validateMessage(messageIdToString(getMsgId(msg)))
-      ps.deliverMessage(msg, messageIdToString(getMsgId(msg)))
+      ps.validateMessage(getMsgIdStr(msg))
+      ps.deliverMessage(msg, getMsgIdStr(msg))
     }
     ps._refreshScores()
     let aScore = ps.score(peerA)
@@ -371,8 +370,8 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      ps.validateMessage(messageIdToString(getMsgId(msg)))
-      ps.deliverMessage(msg, messageIdToString(getMsgId(msg)))
+      ps.validateMessage(getMsgIdStr(msg))
+      ps.deliverMessage(msg, getMsgIdStr(msg))
     }
     // peers A and B should both have zero scores, since the failure penalty hasn't been applied yet
     ps._refreshScores()
@@ -415,7 +414,7 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      await ps.rejectMessage(msg, messageIdToString(getMsgId(msg)), ERR_TOPIC_VALIDATOR_REJECT)
+      await ps.rejectMessage(msg, getMsgIdStr(msg), ERR_TOPIC_VALIDATOR_REJECT)
     }
     ps._refreshScores()
     let aScore = ps.score(peerA)
@@ -444,7 +443,7 @@ describe('PeerScore', () => {
     for (let i = 0; i < nMessages; i++) {
       const msg = makeTestMessage(i, [mytopic])
       msg.receivedFrom = peerA
-      await ps.rejectMessage(msg, messageIdToString(getMsgId(msg)), ERR_TOPIC_VALIDATOR_REJECT)
+      await ps.rejectMessage(msg, getMsgIdStr(msg), ERR_TOPIC_VALIDATOR_REJECT)
     }
     ps._refreshScores()
     let aScore = ps.score(peerA)
@@ -481,12 +480,12 @@ describe('PeerScore', () => {
     msg.receivedFrom = peerA
 
     // insert a record
-    await ps.validateMessage(messageIdToString(getMsgId(msg)))
+    await ps.validateMessage(getMsgIdStr(msg))
 
     // this should have no effect in the score, and subsequent duplicate messages should have no effect either
-    await ps.rejectMessage(msg, messageIdToString(getMsgId(msg)), ERR_TOPIC_VALIDATOR_IGNORE)
+    await ps.rejectMessage(msg, getMsgIdStr(msg), ERR_TOPIC_VALIDATOR_IGNORE)
     msg.receivedFrom = peerB
-    await ps.duplicateMessage(msg, messageIdToString(getMsgId(msg)))
+    await ps.duplicateMessage(msg, getMsgIdStr(msg))
 
     let aScore = ps.score(peerA)
     let bScore = ps.score(peerB)
@@ -501,12 +500,12 @@ describe('PeerScore', () => {
 
     // insert a new record in the message deliveries
     msg.receivedFrom = peerA
-    await ps.validateMessage(messageIdToString(getMsgId(msg)))
+    await ps.validateMessage(getMsgIdStr(msg))
 
     // and reject the message to make sure duplicates are also penalized
-    await ps.rejectMessage(msg, messageIdToString(getMsgId(msg)), ERR_TOPIC_VALIDATOR_REJECT)
+    await ps.rejectMessage(msg, getMsgIdStr(msg), ERR_TOPIC_VALIDATOR_REJECT)
     msg.receivedFrom = peerB
-    await ps.duplicateMessage(msg, messageIdToString(getMsgId(msg)))
+    await ps.duplicateMessage(msg, getMsgIdStr(msg))
 
     aScore = ps.score(peerA)
     bScore = ps.score(peerB)
@@ -521,13 +520,13 @@ describe('PeerScore', () => {
 
     // insert a new record in the message deliveries
     msg.receivedFrom = peerA
-    await ps.validateMessage(messageIdToString(getMsgId(msg)))
+    await ps.validateMessage(getMsgIdStr(msg))
 
     // and reject the message after a duplicate has arrived
     msg.receivedFrom = peerB
-    await ps.duplicateMessage(msg, messageIdToString(getMsgId(msg)))
+    await ps.duplicateMessage(msg, getMsgIdStr(msg))
     msg.receivedFrom = peerA
-    await ps.rejectMessage(msg, messageIdToString(getMsgId(msg)), ERR_TOPIC_VALIDATOR_REJECT)
+    await ps.rejectMessage(msg, getMsgIdStr(msg), ERR_TOPIC_VALIDATOR_REJECT)
 
     aScore = ps.score(peerA)
     bScore = ps.score(peerB)

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai')
 const delay = require('delay')
+const { messageIdToString } = require('../src/utils/messageIdToString')
 const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
 
 const { IWantTracer } = require('../src/tracer')
@@ -39,7 +40,7 @@ describe('IWantTracer', () => {
   it('should track unbroken promises', async function () {
     // like above, but this time we deliver messages to fullfil the promises
     this.timeout(6000)
-    const t = new IWantTracer(getMsgId)
+    const t = new IWantTracer()
     const peerA = 'A'
     const peerB = 'B'
 
@@ -55,7 +56,7 @@ describe('IWantTracer', () => {
     t.addPromise(peerA, msgIds)
     t.addPromise(peerB, msgIds)
 
-    msgs.forEach(msg => t.deliverMessage(msg))
+    msgs.forEach(msg => t.deliverMessage(messageIdToString(getMsgId(msg))))
 
     await delay(constants.GossipsubIWantFollowupTime + 10)
 

--- a/test/tracer.spec.js
+++ b/test/tracer.spec.js
@@ -5,7 +5,7 @@ const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
 
 const { IWantTracer } = require('../src/tracer')
 const constants = require('../src/constants')
-const { makeTestMessage, getMsgId } = require('./utils')
+const { makeTestMessage, getMsgId, getMsgIdStr } = require('./utils')
 
 describe('IWantTracer', () => {
   it('should track broken promises', async function () {
@@ -56,7 +56,7 @@ describe('IWantTracer', () => {
     t.addPromise(peerA, msgIds)
     t.addPromise(peerB, msgIds)
 
-    msgs.forEach(msg => t.deliverMessage(messageIdToString(getMsgId(msg))))
+    msgs.forEach(msg => t.deliverMessage(getMsgIdStr(msg)))
 
     await delay(constants.GossipsubIWantFollowupTime + 10)
 

--- a/test/utils/create-gossipsub.js
+++ b/test/utils/create-gossipsub.js
@@ -1,7 +1,9 @@
 const Gossipsub = require('../../src')
+const {
+  fastMsgIdFn,
+} = require('./msgId')
 
 const {
-  createPeer,
   createPeers,
 } = require('./create-peer')
 
@@ -30,7 +32,7 @@ async function connectGossipsub (gs1, gs2) {
  */
 async function createGossipsubs ({ number = 1, started = true, options = {}} = {}) {
   const libp2ps = await createPeers({ number, started })
-  const gss = libp2ps.map(libp2p => new Gossipsub(libp2p, options))
+  const gss = libp2ps.map(libp2p => new Gossipsub(libp2p, {...options, fastMsgIdFn: fastMsgIdFn}))
 
   if (started) {
     await Promise.all(

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { expect } = require('chai')
-
+const { messageIdToString } = require('../../src/utils/messageIdToString')
 const FloodSub = require('libp2p-floodsub')
 const PeerId = require('peer-id')
 const delay = require('delay')
@@ -46,7 +46,7 @@ for (const [k, v] of Object.entries({
   exports[k] = v
 }
 
-exports.getMsgId = (msg) => {
+const getMsgId = (msg) => {
   const from = uint8ArrayFromString(msg.from)
   const seqno = uint8ArrayFromString(msg.seqno)
   const result = new Uint8Array(from.length + seqno.length)
@@ -54,6 +54,10 @@ exports.getMsgId = (msg) => {
   result.set(seqno, from.length)
   return result
 }
+
+exports.getMsgId = getMsgId
+
+exports.getMsgIdStr = (msg) => messageIdToString(getMsgId(msg))
 
 exports.waitForAllNodesToBePeered = async (peers, attempts = 10, delayMs = 100) => {
   const nodeIds = peers.map(peer => peer.peerId.toB58String())

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -1,11 +1,9 @@
 'use strict'
 
 const { expect } = require('chai')
-const { messageIdToString } = require('../../src/utils/messageIdToString')
 const FloodSub = require('libp2p-floodsub')
 const PeerId = require('peer-id')
 const delay = require('delay')
-const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
 
 exports.first = (map) => map.values().next().value
 
@@ -41,23 +39,11 @@ exports.createFloodsubNode = createFloodsubNode
 for (const [k, v] of Object.entries({
   ...require('./create-peer'),
   ...require('./create-gossipsub'),
-  ...require('./make-test-message')
+  ...require('./make-test-message'),
+  ...require('./msgId'),
 })) {
   exports[k] = v
 }
-
-const getMsgId = (msg) => {
-  const from = uint8ArrayFromString(msg.from)
-  const seqno = uint8ArrayFromString(msg.seqno)
-  const result = new Uint8Array(from.length + seqno.length)
-  result.set(from, 0)
-  result.set(seqno, from.length)
-  return result
-}
-
-exports.getMsgId = getMsgId
-
-exports.getMsgIdStr = (msg) => messageIdToString(getMsgId(msg))
 
 exports.waitForAllNodesToBePeered = async (peers, attempts = 10, delayMs = 100) => {
   const nodeIds = peers.map(peer => peer.peerId.toB58String())

--- a/test/utils/msgId.js
+++ b/test/utils/msgId.js
@@ -1,0 +1,22 @@
+const SHA256 = require('@chainsafe/as-sha256')
+const { fromString: uint8ArrayFromString } = require('uint8arrays/from-string')
+const { messageIdToString } = require('../../src/utils/messageIdToString')
+
+const getMsgId = (msg) => {
+  const from = uint8ArrayFromString(msg.from)
+  const seqno = uint8ArrayFromString(msg.seqno)
+  const result = new Uint8Array(from.length + seqno.length)
+  result.set(from, 0)
+  result.set(seqno, from.length)
+  return result
+}
+
+const getMsgIdStr = (msg) => messageIdToString(getMsgId(msg))
+
+const fastMsgIdFn = (msg) => messageIdToString(SHA256.default.digest(msg.data))
+
+module.exports = {
+  getMsgId,
+  getMsgIdStr,
+  fastMsgIdFn,
+}

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1102,22 +1102,16 @@ class Gossipsub extends Pubsub {
    * @param {InMessage} msg
    */
   async getCanonicalMsgIdStr (msg: InMessage): Promise<string> {
-    const cachedMsgId = this.getCachedMsgId(msg)
-    if (cachedMsgId) {
-      return messageIdToString(cachedMsgId)
-    }
-
-    const fastMsgIdStr = this.getFastMsgIdStr(msg)
-    return this.fastMsgIdCache.get(fastMsgIdStr) ?? messageIdToString(await this.getMsgId(msg))
+    return this.getCachedMsgIdStr(msg) ?? this.fastMsgIdCache.get(this.getFastMsgIdStr(msg)) ?? messageIdToString(await this.getMsgId(msg))
   }
 
   /**
-   * Application should override this to return its cached message id without computing it.
-   * Return undefine if it does not have it
+   * Application should override this to return its cached message id string without computing it.
+   * Return undefined if it does not have it
    * @param {InMessage} msg
    * @returns
    */
-  getCachedMsgId (msg: InMessage): Uint8Array | undefined {
+  getCachedMsgIdStr (msg: InMessage): string | undefined {
     return undefined
   }
 

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -453,7 +453,7 @@ class Gossipsub extends Pubsub {
    * @returns {Promise<void>}
    */
   async _processRpcMessage (msg: InMessage): Promise<void> {
-    const fastMsgIdStr = messageIdToString(SHA256.digest(msg.data))
+    const fastMsgIdStr = this.getFastMsgIdStr(msg)
 
     // Ignore if we've already seen the message
     let canonicalMsgIdStr = this.fastMsgIdCache.get(fastMsgIdStr)
@@ -1098,7 +1098,7 @@ class Gossipsub extends Pubsub {
       return messageIdToString(cachedMsgId)
     }
 
-    const fastMsgIdStr = messageIdToString(SHA256.digest(msg.data))
+    const fastMsgIdStr = this.getFastMsgIdStr(msg)
     return this.fastMsgIdCache.get(fastMsgIdStr) ?? messageIdToString(await this.getMsgId(msg))
   }
 
@@ -1110,6 +1110,14 @@ class Gossipsub extends Pubsub {
    */
   getCachedMsgId (msg: InMessage): Uint8Array | undefined {
     return undefined
+  }
+
+  /**
+   * The default implementation uses SHA256 hash, application could override if needed.
+   * @returns
+   */
+  getFastMsgIdStr (msg: InMessage): string {
+    return messageIdToString(SHA256.digest(msg.data))
   }
 
   /**

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1089,12 +1089,27 @@ class Gossipsub extends Pubsub {
   }
 
   /**
-   * Prefer the fast cache over this.getMsgId()
-   * @param {InMessage} msg
+   * Get from the application cache first, then from the fast cache, then from this.getMsgId()
+   * @param {InMessage} message
    */
   async getCanonicalMessageIdStr (message: InMessage): Promise<string> {
+    const cachedMsgId = this.getCachedMsgId(message)
+    if (cachedMsgId) {
+      return messageIdToString(cachedMsgId)
+    }
+
     const fastMsgIdStr = messageIdToString(SHA256.digest(message.data))
     return this.fastMsgIdCache.get(fastMsgIdStr) ?? messageIdToString(await this.getMsgId(message))
+  }
+
+  /**
+   * Application should override this to return its cached message id without computing it.
+   * Return undefine if it does not have it
+   * @param {InMessage} message
+   * @returns
+   */
+  getCachedMsgId (message: InMessage): Uint8Array | undefined {
+    return undefined
   }
 
   /**

--- a/ts/interfaces.ts
+++ b/ts/interfaces.ts
@@ -8,3 +8,4 @@ export interface AddrInfo {
 }
 
 export type MessageIdFunction = (msg: InMessage) => Promise<Uint8Array> | Uint8Array;
+export type MessageIdStrFunction = (msg: InMessage) => Promise<string>;

--- a/ts/message-cache.ts
+++ b/ts/message-cache.ts
@@ -3,7 +3,7 @@ import { MessageIdFunction } from './interfaces'
 import { messageIdFromString, messageIdToString } from './utils'
 
 export interface CacheEntry {
-  msgID: Uint8Array
+  msgId: Uint8Array
   topics: string[]
 }
 
@@ -52,18 +52,18 @@ export class MessageCache {
    */
   async put (msg: InMessage, msgIdStr: string): Promise<void> {
     this.msgs.set(msgIdStr, msg)
-    const msgID = messageIdFromString(msgIdStr)
-    this.history[0].push({ msgID, topics: msg.topicIDs })
+    const msgId = messageIdFromString(msgIdStr)
+    this.history[0].push({ msgId: msgId, topics: msg.topicIDs })
   }
 
   /**
    * Retrieves a message from the cache by its ID, if it is still present
    *
-   * @param {Uint8Array} msgID
+   * @param {Uint8Array} msgId
    * @returns {Message}
    */
-  get (msgID: Uint8Array): InMessage | undefined {
-    return this.msgs.get(messageIdToString(msgID))
+  get (msgId: Uint8Array): InMessage | undefined {
+    return this.msgs.get(messageIdToString(msgId))
   }
 
   /**
@@ -100,19 +100,19 @@ export class MessageCache {
    * @returns {Array<Uint8Array>}
    */
   getGossipIDs (topic: string): Uint8Array[] {
-    const msgIDs: Uint8Array[] = []
+    const msgIds: Uint8Array[] = []
     for (let i = 0; i < this.gossip; i++) {
       this.history[i].forEach((entry) => {
         for (const t of entry.topics) {
           if (t === topic) {
-            msgIDs.push(entry.msgID)
+            msgIds.push(entry.msgId)
             break
           }
         }
       })
     }
 
-    return msgIDs
+    return msgIds
   }
 
   /**
@@ -123,7 +123,7 @@ export class MessageCache {
   shift (): void {
     const last = this.history[this.history.length - 1]
     last.forEach((entry) => {
-      const msgIdStr = messageIdToString(entry.msgID)
+      const msgIdStr = messageIdToString(entry.msgId)
       this.msgs.delete(msgIdStr)
       this.peertx.delete(msgIdStr)
     })

--- a/ts/score/message-deliveries.ts
+++ b/ts/score/message-deliveries.ts
@@ -1,6 +1,5 @@
 import { TimeCacheDuration } from '../constants'
 import Denque from 'denque'
-import { messageIdToString } from '../utils'
 
 export enum DeliveryRecordStatus {
   /**
@@ -34,7 +33,7 @@ interface DeliveryQueueEntry {
 }
 
 /**
- * Map of message ID to DeliveryRecord
+ * Map of canonical message ID to DeliveryRecord
  *
  * Maintains an internal queue for efficient gc of old messages
  */
@@ -47,8 +46,7 @@ export class MessageDeliveries {
     this.queue = new Denque()
   }
 
-  ensureRecord (msgId: Uint8Array): DeliveryRecord {
-    const msgIdStr = messageIdToString(msgId)
+  ensureRecord (msgIdStr: string): DeliveryRecord {
     let drec = this.records.get(msgIdStr)
     if (drec) {
       return drec

--- a/ts/score/peer-score.ts
+++ b/ts/score/peer-score.ts
@@ -321,12 +321,12 @@ export class PeerScore {
   }
 
   /**
-   * @param {InMessage} message
+   * @param {InMessage} msg
    * @returns {Promise<void>}
    */
-  async deliverMessage (message: InMessage, msgIdStr: string): Promise<void> {
-    const id = message.receivedFrom
-    this._markFirstMessageDelivery(id, message)
+  async deliverMessage (msg: InMessage, msgIdStr: string): Promise<void> {
+    const id = msg.receivedFrom
+    this._markFirstMessageDelivery(id, msg)
 
     const drec = this.deliveryRecords.ensureRecord(msgIdStr)
     const now = Date.now()
@@ -347,22 +347,22 @@ export class PeerScore {
       // this check is to make sure a peer can't send us a message twice and get a double count
       // if it is a first delivery.
       if (p !== id) {
-        this._markDuplicateMessageDelivery(p, message)
+        this._markDuplicateMessageDelivery(p, msg)
       }
     })
   }
 
   /**
-   * @param {InMessage} message
+   * @param {InMessage} msg
    * @param {string} reason
    * @returns {Promise<void>}
    */
-  async rejectMessage (message: InMessage, msgIdStr: string, reason: string): Promise<void> {
-    const id = message.receivedFrom
+  async rejectMessage (msg: InMessage, msgIdStr: string, reason: string): Promise<void> {
+    const id = msg.receivedFrom
     switch (reason) {
       case ERR_MISSING_SIGNATURE:
       case ERR_INVALID_SIGNATURE:
-        this._markInvalidMessageDelivery(id, message)
+        this._markInvalidMessageDelivery(id, msg)
         return
     }
 
@@ -387,18 +387,18 @@ export class PeerScore {
     // mark the message as invalid and penalize peers that have already forwarded it.
     drec.status = DeliveryRecordStatus.invalid
 
-    this._markInvalidMessageDelivery(id, message)
+    this._markInvalidMessageDelivery(id, msg)
     drec.peers.forEach(p => {
-      this._markInvalidMessageDelivery(p, message)
+      this._markInvalidMessageDelivery(p, msg)
     })
   }
 
   /**
-   * @param {InMessage} message
+   * @param {InMessage} msg
    * @returns {Promise<void>}
    */
-  async duplicateMessage (message: InMessage, msgIdStr: string): Promise<void> {
-    const id = message.receivedFrom
+  async duplicateMessage (msg: InMessage, msgIdStr: string): Promise<void> {
+    const id = msg.receivedFrom
     const drec = this.deliveryRecords.ensureRecord(msgIdStr)
 
     if (drec.peers.has(id)) {
@@ -415,11 +415,11 @@ export class PeerScore {
       case DeliveryRecordStatus.valid:
         // mark the peer delivery time to only count a duplicate delivery once.
         drec.peers.add(id)
-        this._markDuplicateMessageDelivery(id, message, drec.validated)
+        this._markDuplicateMessageDelivery(id, msg, drec.validated)
         break
       case DeliveryRecordStatus.invalid:
         // we no longer track delivery time
-        this._markInvalidMessageDelivery(id, message)
+        this._markInvalidMessageDelivery(id, msg)
         break
     }
   }
@@ -427,16 +427,16 @@ export class PeerScore {
   /**
    * Increments the "invalid message deliveries" counter for all scored topics the message is published in.
    * @param {string} id
-   * @param {InMessage} message
+   * @param {InMessage} msg
    * @returns {void}
    */
-  _markInvalidMessageDelivery (id: string, message: InMessage): void {
+  _markInvalidMessageDelivery (id: string, msg: InMessage): void {
     const pstats = this.peerStats.get(id)
     if (!pstats) {
       return
     }
 
-    message.topicIDs.forEach(topic => {
+    msg.topicIDs.forEach(topic => {
       const tstats = ensureTopicStats(topic, pstats, this.params)
       if (!tstats) {
         return
@@ -451,16 +451,16 @@ export class PeerScore {
    * Increments the "first message deliveries" counter for all scored topics the message is published in,
    * as well as the "mesh message deliveries" counter, if the peer is in the mesh for the topic.
    * @param {string} id
-   * @param {InMessage} message
+   * @param {InMessage} msg
    * @returns {void}
    */
-  _markFirstMessageDelivery (id: string, message: InMessage): void {
+  _markFirstMessageDelivery (id: string, msg: InMessage): void {
     const pstats = this.peerStats.get(id)
     if (!pstats) {
       return
     }
 
-    message.topicIDs.forEach(topic => {
+    msg.topicIDs.forEach(topic => {
       const tstats = ensureTopicStats(topic, pstats, this.params)
       if (!tstats) {
         return
@@ -489,11 +489,11 @@ export class PeerScore {
    * Increments the "mesh message deliveries" counter for messages we've seen before,
    * as long the message was received within the P3 window.
    * @param {string} id
-   * @param {InMessage} message
+   * @param {InMessage} msg
    * @param {number} validatedTime
    * @returns {void}
    */
-  _markDuplicateMessageDelivery (id: string, message: InMessage, validatedTime = 0): void {
+  _markDuplicateMessageDelivery (id: string, msg: InMessage, validatedTime = 0): void {
     const pstats = this.peerStats.get(id)
     if (!pstats) {
       return
@@ -501,7 +501,7 @@ export class PeerScore {
 
     const now = validatedTime ? Date.now() : 0
 
-    message.topicIDs.forEach(topic => {
+    msg.topicIDs.forEach(topic => {
       const tstats = ensureTopicStats(topic, pstats, this.params)
       if (!tstats) {
         return

--- a/ts/tracer.ts
+++ b/ts/tracer.ts
@@ -26,7 +26,7 @@ export class IWantTracer {
   }
 
   /**
-   * Track a promise to deliver a message from a list of msgIDs we are requesting
+   * Track a promise to deliver a message from a list of msgIds we are requesting
    * @param {string} p peer id
    * @param {string[]} msgIds
    * @returns {void}

--- a/ts/tracer.ts
+++ b/ts/tracer.ts
@@ -1,6 +1,4 @@
 import { GossipsubIWantFollowupTime } from './constants'
-import { InMessage } from 'libp2p-interfaces/src/pubsub'
-import { MessageIdStrFunction } from './interfaces'
 import { messageIdToString } from './utils'
 import pubsubErrors = require('libp2p-interfaces/src/pubsub/errors')
 
@@ -18,14 +16,12 @@ const {
  * These 'promises' are merely expectations of a peer's behavior.
  */
 export class IWantTracer {
-  getMsgStrId: MessageIdStrFunction
   /**
    * Promises to deliver a message
    * Map per message id, per peer, promise expiration time
    */
   promises: Map<string, Map<string, number>>
-  constructor (getMsgStrId: MessageIdStrFunction) {
-    this.getMsgStrId = getMsgStrId
+  constructor () {
     this.promises = new Map()
   }
 
@@ -81,29 +77,27 @@ export class IWantTracer {
 
   /**
    * Someone delivered a message, stop tracking promises for it
-   * @param {InMessage} msg
+   * @param {string} msgIdStr
    * @returns {Promise<void>}
    */
-  async deliverMessage (msg: InMessage): Promise<void> {
-    const msgIdStr = await this.getMsgStrId(msg)
+  async deliverMessage (msgIdStr: string): Promise<void> {
     this.promises.delete(msgIdStr)
   }
 
   /**
    * A message got rejected, so we can stop tracking promises and let the score penalty apply from invalid message delivery,
    * unless its an obviously invalid message.
-   * @param {InMessage} msg
+   * @param {string} msgIdStr
    * @param {string} reason
    * @returns {Promise<void>}
    */
-  async rejectMessage (msg: InMessage, reason: string): Promise<void> {
+  async rejectMessage (msgIdStr: string, reason: string): Promise<void> {
     switch (reason) {
       case ERR_INVALID_SIGNATURE:
       case ERR_MISSING_SIGNATURE:
         return
     }
 
-    const msgIdStr = await this.getMsgStrId(msg)
     this.promises.delete(msgIdStr)
   }
 

--- a/ts/tracer.ts
+++ b/ts/tracer.ts
@@ -1,6 +1,6 @@
 import { GossipsubIWantFollowupTime } from './constants'
 import { InMessage } from 'libp2p-interfaces/src/pubsub'
-import { MessageIdFunction } from './interfaces'
+import { MessageIdStrFunction } from './interfaces'
 import { messageIdToString } from './utils'
 import pubsubErrors = require('libp2p-interfaces/src/pubsub/errors')
 
@@ -18,14 +18,14 @@ const {
  * These 'promises' are merely expectations of a peer's behavior.
  */
 export class IWantTracer {
-  getMsgId: MessageIdFunction
+  getMsgStrId: MessageIdStrFunction
   /**
    * Promises to deliver a message
    * Map per message id, per peer, promise expiration time
    */
   promises: Map<string, Map<string, number>>
-  constructor (getMsgId: MessageIdFunction) {
-    this.getMsgId = getMsgId
+  constructor (getMsgStrId: MessageIdStrFunction) {
+    this.getMsgStrId = getMsgStrId
     this.promises = new Map()
   }
 
@@ -85,8 +85,7 @@ export class IWantTracer {
    * @returns {Promise<void>}
    */
   async deliverMessage (msg: InMessage): Promise<void> {
-    const msgId = await this.getMsgId(msg)
-    const msgIdStr = messageIdToString(msgId)
+    const msgIdStr = await this.getMsgStrId(msg)
     this.promises.delete(msgIdStr)
   }
 
@@ -104,8 +103,7 @@ export class IWantTracer {
         return
     }
 
-    const msgId = await this.getMsgId(msg)
-    const msgIdStr = messageIdToString(msgId)
+    const msgIdStr = await this.getMsgStrId(msg)
     this.promises.delete(msgIdStr)
   }
 

--- a/ts/utils/messageIdToString.ts
+++ b/ts/utils/messageIdToString.ts
@@ -1,5 +1,10 @@
+import { fromString } from 'uint8arrays/from-string'
 import { toString } from 'uint8arrays/to-string'
 
 export function messageIdToString (msgId: Uint8Array): string {
   return toString(msgId, 'base64')
+}
+
+export function messageIdFromString (msgId: string): Uint8Array {
+  return fromString(msgId, 'base64')
 }

--- a/ts/utils/time-cache.ts
+++ b/ts/utils/time-cache.ts
@@ -21,9 +21,8 @@ export class SimpleTimeCache<T> {
     this.entries = new Map()
     this.validityMs = options.validityMs
 
-    if (this.validityMs <= 0) {
-      throw Error(`Invalid validityMs ${this.validityMs}`)
-    }
+    // allow negative validityMs so that this does not cache anything, spec test compliance.spec.js
+    // sends duplicate messages and expect peer to receive all. Application likely uses positive validityMs
   }
 
   put (key: string, value: T): void {
@@ -50,5 +49,15 @@ export class SimpleTimeCache<T> {
 
   has (key: string): boolean {
     return this.entries.has(key)
+  }
+
+  get (key: string): T | undefined {
+    const value = this.entries.get(key)
+    return (value && value.validUntilMs >= Date.now()) ? value.value : undefined
+  }
+
+  clear (): void {
+    this.entries = new Map()
+    this.lastPruneTime = 0
   }
 }

--- a/ts/utils/time-cache.ts
+++ b/ts/utils/time-cache.ts
@@ -2,13 +2,18 @@ type SimpleTimeCacheOpts = {
   validityMs: number
 }
 
+type CacheValue<T> = {
+  value: T
+  validUntilMs: number
+}
+
 /**
  * This is similar to https://github.com/daviddias/time-cache/blob/master/src/index.js
  * for our own need, we don't use lodash throttle to improve performance.
  * This gives 4x - 5x performance gain compared to npm TimeCache
  */
-export class SimpleTimeCache {
-  private entries: Map<string, number>;
+export class SimpleTimeCache<T> {
+  private entries: Map<string, CacheValue<T>>;
   private validityMs: number;
   private lastPruneTime = 0;
 
@@ -21,8 +26,8 @@ export class SimpleTimeCache {
     }
   }
 
-  put (key: string): void {
-    this.entries.set(key, Date.now())
+  put (key: string, value: T): void {
+    this.entries.set(key, { value, validUntilMs: Date.now() + this.validityMs })
     this.prune()
   }
 
@@ -34,7 +39,7 @@ export class SimpleTimeCache {
     this.lastPruneTime = now
 
     for (const [k, v] of this.entries.entries()) {
-      if (v + this.validityMs < now) {
+      if (v.validUntilMs < now) {
         this.entries.delete(k)
       } else {
         // sort by insertion order


### PR DESCRIPTION
**Motivation**
+ Gossipsub is designed to have message redundancy, right now we have to calculate 3.97 times per message data in average, in the worse case we calculate 10/11 times per message data

**Description**
+ Follow other clients to have a cheaper faster message id just for message de-duplication, so we have fast message id and canonical message id
+ Key as the sha256 of the message (fast message id), value as the canonical message id => enhance `SimpleTimeCache` for this
+ Instead of passing `getMsgId()` function to other classes (PeerScore, GossipTracer, MessageCache) in the constructor, just pass message id through method as we always have them in the consumer code which make it simpler (and Lighthouse does this!)
+ Use the new `getCanonicalMessageIdStr()` function in all places instead of `getMsgId()` since we can't base on `getMsgId()` in lodestar, the message is removed very quickly from WeakMap
+ `getCanonicalMessageIdStr()`: get from the newly created `getCachedMsgId()` first, then the fast message id cache, then `getMsgId`

**Test result**
+ Message id is calculated 1.02 times per message, max is 2
+ This uses the default cache time which is 30s, should we increase it? Lighthouse uses a duration of 33 slots https://github.com/sigp/lighthouse/blob/fff01b24ddedcd54486e374460855ca20d3dd232/beacon_node/eth2_libp2p/src/config.rs#L36 . We can change the `seenTTL` option anyway
+ With this 30s cache, it takes 1.2MB (and 9556 cache entries) if I use `subscribeAllSubnets` flag in lodestar
<img width="1476" alt="Screen Shot 2021-12-22 at 11 01 13" src="https://user-images.githubusercontent.com/10568965/147033727-88df65b6-9d0e-48df-a305-f3853f6dcf4f.png">
