### PR TITLE
Use node 16 to for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Nodejs
         uses: actions/setup-node@v1
         with:
-          node-version: '14'
+          node-version: '16'
           always-auth: true
           registry-url: 'https://registry.npmjs.org'
         env:


### PR DESCRIPTION
**Motivation**
+ Fix error in release workflow https://github.com/ChainSafe/js-libp2p-gossipsub/runs/5184299589?check_suite_focus=true

```
[2/4] Fetching packages...
error peer-id@0.16.0: The engine "node" is incompatible with this module. Expected version ">=15.0.0". Got "14.19.0"
error Found incompatible module.
```

**Description**
+ Use node 16 for release workflow