### PR TITLE
Use libp2p release version for devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "it-pair": "^1.0.0",
-    "libp2p": "^0.36.2",
+    "libp2p": "0.36.1",
     "libp2p-floodsub": "^0.29.0",
     "libp2p-interfaces-compliance-tests": "^4.0.6",
     "libp2p-mplex": "^0.10.3",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
     "it-pair": "^1.0.0",
-    "libp2p": "libp2p/js-libp2p#feat/async-peerstore",
+    "libp2p": "^0.36.2",
     "libp2p-floodsub": "^0.29.0",
     "libp2p-interfaces-compliance-tests": "^4.0.6",
     "libp2p-mplex": "^0.10.3",


### PR DESCRIPTION
**Motivation**
+ Failed release workflow https://github.com/ChainSafe/js-libp2p-gossipsub/runs/5187646222?check_suite_focus=true

**Description**
+ Fix libp2p version as noted in https://github.com/ChainSafe/js-libp2p-gossipsub/pull/182/files#r776953509