### PR TITLE
_publish: Only compute score if peer stream has FloodsubID protocol

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1176,12 +1176,11 @@ class Gossipsub extends Pubsub {
 
         // floodsub peers
         peersInTopic.forEach((id) => {
-          const score = this.score.score(id)
           const peerStreams = this.peers.get(id)
           if (!peerStreams) {
             return
           }
-          if (peerStreams.protocol === constants.FloodsubID && score >= this._options.scoreThresholds.publishThreshold) {
+          if (peerStreams.protocol === constants.FloodsubID && this.score.score(id) >= this._options.scoreThresholds.publishThreshold) {
             tosend.add(id)
           }
         })


### PR DESCRIPTION
**Motivation**
+ Avoid computing score when it's not really necessary

**Description:**
+ _publish: Only compute score if peer stream has FloodsubID protocol
+ It's not a big improvement with `master` branch since we cache score already
+ There's another `this.score.score(id)` call some lines below but it's ok since we have score cache
Close #188 