### PR TITLE
Remove redundant JSDocs

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "promisify-es6": "^1.0.3",
     "sinon": "^11.1.1",
     "time-cache": "^0.3.0",
-    "typescript": "4.0.x",
+    "typescript": "4.6.2",
     "util": "^0.12.3"
   },
   "contributors": [

--- a/ts/get-gossip-peers.ts
+++ b/ts/get-gossip-peers.ts
@@ -5,12 +5,7 @@ import Gossipsub = require('./index')
  * Given a topic, returns up to count peers subscribed to that topic
  * that pass an optional filter function
  *
- * @param {Gossipsub} router
- * @param {String} topic
- * @param {Number} count
- * @param {Function} [filter] a function to filter acceptable peers
- * @returns {Set<string>}
- *
+ * @param filter a function to filter acceptable peers
  */
 export function getGossipPeers(
   router: Gossipsub,

--- a/ts/heartbeat.ts
+++ b/ts/heartbeat.ts
@@ -5,20 +5,13 @@ import Gossipsub = require('./index')
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 
 export class Heartbeat {
-  gossipsub: Gossipsub
   _heartbeatTimer: {
     _intervalId: NodeJS.Timeout | undefined
     runPeriodically(fn: () => void, period: number): void
     cancel(): void
   } | null
 
-  /**
-   * @param {Object} gossipsub
-   * @constructor
-   */
-  constructor(gossipsub: Gossipsub) {
-    this.gossipsub = gossipsub
-  }
+  constructor(private readonly gossipsub: Gossipsub) {}
 
   start(): void {
     if (this._heartbeatTimer) {
@@ -46,8 +39,6 @@ export class Heartbeat {
 
   /**
    * Unmounts the gossipsub protocol and shuts down every connection
-   * @override
-   * @returns {void}
    */
   stop(): void {
     if (!this._heartbeatTimer) {
@@ -60,8 +51,6 @@ export class Heartbeat {
 
   /**
    * Maintains the mesh and fanout maps in gossipsub.
-   *
-   * @returns {void}
    */
   _heartbeat(): void {
     const { D, Dlo, Dhi, Dscore, Dout, fanoutTTL } = this.gossipsub._options

--- a/ts/heartbeat.ts
+++ b/ts/heartbeat.ts
@@ -11,6 +11,9 @@ export class Heartbeat {
     cancel(): void
   } | null
 
+  // TODO: Bump eslint, since current version complains with 'no-useless-constructor'
+  // When this constructor is necessary to declare private arg gossipsub
+  // eslint-disable-next-line no-useless-constructor
   constructor(private readonly gossipsub: Gossipsub) {}
 
   start(): void {

--- a/ts/message-cache.ts
+++ b/ts/message-cache.ts
@@ -8,47 +8,22 @@ export interface CacheEntry {
 }
 
 export class MessageCache {
-  msgs: Map<string, InMessage>
-  peertx: Map<string, Map<string, number>>
-  history: CacheEntry[][]
+  msgs = new Map<string, InMessage>()
+  peertx = new Map<string, Map<string, number>>()
+  history: CacheEntry[][] = []
   gossip: number
   msgIdFn: MessageIdFunction
 
-  /**
-   * @param {Number} gossip
-   * @param {Number} history
-   * @param {msgIdFn} msgIdFn a function that returns message id from a message
-   *
-   * @constructor
-   */
   constructor(gossip: number, history: number) {
-    /**
-     * @type {Map<string, RPC.Message>}
-     */
-    this.msgs = new Map()
-
-    this.peertx = new Map()
-
-    /**
-     * @type {Array<Array<CacheEntry>>}
-     */
-    this.history = []
     for (let i = 0; i < history; i++) {
       this.history[i] = []
     }
 
-    /**
-     * @type {Number}
-     */
     this.gossip = gossip
   }
 
   /**
    * Adds a message to the current window and the cache
-   *
-   * @param {string} msgIdStr
-   * @param {RPC.Message} msg
-   * @returns {Promise<void>}
    */
   async put(msg: InMessage, msgIdStr: string): Promise<void> {
     this.msgs.set(msgIdStr, msg)
@@ -58,9 +33,6 @@ export class MessageCache {
 
   /**
    * Retrieves a message from the cache by its ID, if it is still present
-   *
-   * @param {Uint8Array} msgId
-   * @returns {Message}
    */
   get(msgId: Uint8Array): InMessage | undefined {
     return this.msgs.get(messageIdToString(msgId))
@@ -70,10 +42,6 @@ export class MessageCache {
    * Retrieves a message from the cache by its ID, if it is present
    * for a specific peer.
    * Returns the message and the number of times the peer has requested the message
-   *
-   * @param {string} msgIdStr
-   * @param {string} p
-   * @returns {[InMessage | undefined, number]}
    */
   getForPeer(msgIdStr: string, p: string): [InMessage | undefined, number] {
     const msg = this.msgs.get(msgIdStr)
@@ -94,10 +62,6 @@ export class MessageCache {
 
   /**
    * Retrieves a list of message IDs for a given topic
-   *
-   * @param {String} topic
-   *
-   * @returns {Array<Uint8Array>}
    */
   getGossipIDs(topic: string): Uint8Array[] {
     const msgIds: Uint8Array[] = []
@@ -117,8 +81,6 @@ export class MessageCache {
 
   /**
    * Shifts the current window, discarding messages older than this.history.length of the cache
-   *
-   * @returns {void}
    */
   shift(): void {
     const last = this.history[this.history.length - 1]

--- a/ts/score/peer-score.ts
+++ b/ts/score/peer-score.ts
@@ -56,7 +56,6 @@ export class PeerScore {
 
   /**
    * Start PeerScore instance
-   * @returns {void}
    */
   start(): void {
     if (this._backgroundInterval) {
@@ -69,7 +68,6 @@ export class PeerScore {
 
   /**
    * Stop PeerScore instance
-   * @returns {void}
    */
   stop(): void {
     if (!this._backgroundInterval) {
@@ -86,7 +84,6 @@ export class PeerScore {
 
   /**
    * Periodic maintenance
-   * @returns {void}
    */
   background(): void {
     this._refreshScores()
@@ -96,7 +93,6 @@ export class PeerScore {
 
   /**
    * Decays scores, and purges score records for disconnected peers once their expiry has elapsed.
-   * @returns {void}
    */
   _refreshScores(): void {
     const now = Date.now()
@@ -163,8 +159,6 @@ export class PeerScore {
 
   /**
    * Return the score for a peer
-   * @param {string} id
-   * @returns {Number}
    */
   score(id: string): number {
     const pstats = this.peerStats.get(id)
@@ -190,9 +184,6 @@ export class PeerScore {
 
   /**
    * Apply a behavioural penalty to a peer
-   * @param {string} id
-   * @param {Number} penalty
-   * @returns {void}
    */
   addPenalty(id: string, penalty: number): void {
     const pstats = this.peerStats.get(id)
@@ -203,10 +194,6 @@ export class PeerScore {
     this.scoreCache.set(id, { score: null, cacheUntil: 0 })
   }
 
-  /**
-   * @param {string} id
-   * @returns {void}
-   */
   addPeer(id: string): void {
     // create peer stats (not including topic stats for each topic to be scored)
     // topic stats will be added as needed
@@ -221,10 +208,6 @@ export class PeerScore {
     pstats.ips = ips
   }
 
-  /**
-   * @param {string} id
-   * @returns {void}
-   */
   removePeer(id: string): void {
     const pstats = this.peerStats.get(id)
     if (!pstats) {
@@ -260,11 +243,6 @@ export class PeerScore {
     pstats.expire = Date.now() + this.params.retainScore
   }
 
-  /**
-   * @param {string} id
-   * @param {String} topic
-   * @returns {void}
-   */
   graft(id: string, topic: string): void {
     const pstats = this.peerStats.get(id)
     if (!pstats) {
@@ -283,11 +261,6 @@ export class PeerScore {
     this.scoreCache.set(id, { score: null, cacheUntil: 0 })
   }
 
-  /**
-   * @param {string} id
-   * @param {string} topic
-   * @returns {void}
-   */
   prune(id: string, topic: string): void {
     const pstats = this.peerStats.get(id)
     if (!pstats) {
@@ -317,10 +290,6 @@ export class PeerScore {
     this.deliveryRecords.ensureRecord(msgIdStr)
   }
 
-  /**
-   * @param {InMessage} msg
-   * @returns {Promise<void>}
-   */
   async deliverMessage(msg: InMessage, msgIdStr: string): Promise<void> {
     const id = msg.receivedFrom
     this._markFirstMessageDelivery(id, msg)
@@ -351,11 +320,6 @@ export class PeerScore {
     })
   }
 
-  /**
-   * @param {InMessage} msg
-   * @param {string} reason
-   * @returns {Promise<void>}
-   */
   async rejectMessage(msg: InMessage, msgIdStr: string, reason: string): Promise<void> {
     const id = msg.receivedFrom
     switch (reason) {
@@ -394,10 +358,6 @@ export class PeerScore {
     })
   }
 
-  /**
-   * @param {InMessage} msg
-   * @returns {Promise<void>}
-   */
   async duplicateMessage(msg: InMessage, msgIdStr: string): Promise<void> {
     const id = msg.receivedFrom
     const drec = this.deliveryRecords.ensureRecord(msgIdStr)
@@ -427,9 +387,6 @@ export class PeerScore {
 
   /**
    * Increments the "invalid message deliveries" counter for all scored topics the message is published in.
-   * @param {string} id
-   * @param {InMessage} msg
-   * @returns {void}
    */
   _markInvalidMessageDelivery(id: string, msg: InMessage): void {
     const pstats = this.peerStats.get(id)
@@ -451,9 +408,6 @@ export class PeerScore {
   /**
    * Increments the "first message deliveries" counter for all scored topics the message is published in,
    * as well as the "mesh message deliveries" counter, if the peer is in the mesh for the topic.
-   * @param {string} id
-   * @param {InMessage} msg
-   * @returns {void}
    */
   _markFirstMessageDelivery(id: string, msg: InMessage): void {
     const pstats = this.peerStats.get(id)
@@ -489,10 +443,6 @@ export class PeerScore {
   /**
    * Increments the "mesh message deliveries" counter for messages we've seen before,
    * as long the message was received within the P3 window.
-   * @param {string} id
-   * @param {InMessage} msg
-   * @param {number} validatedTime
-   * @returns {void}
    */
   _markDuplicateMessageDelivery(id: string, msg: InMessage, validatedTime = 0): void {
     const pstats = this.peerStats.get(id)
@@ -532,8 +482,6 @@ export class PeerScore {
 
   /**
    * Gets the current IPs for a peer.
-   * @param {string} id
-   * @returns {Array<string>}
    */
   _getIPs(id: string): string[] {
     return this._connectionManager.getAll(PeerId.createFromB58String(id)).map((c) => c.remoteAddr.toOptions().host)
@@ -541,10 +489,6 @@ export class PeerScore {
 
   /**
    * Adds tracking for the new IPs in the list, and removes tracking from the obsolete IPs.
-   * @param {string} id
-   * @param {Array<string>} newIPs
-   * @param {Array<string>} oldIPs
-   * @returns {void}
    */
   _setIPs(id: string, newIPs: string[], oldIPs: string[]): void {
     // add the new IPs to the tracking
@@ -591,9 +535,6 @@ export class PeerScore {
 
   /**
    * Removes an IP list from the tracking list for a peer.
-   * @param {string} id
-   * @param {Array<string>} ips
-   * @returns {void}
    */
   _removeIPs(id: string, ips: string[]): void {
     ips.forEach((ip) => {
@@ -613,7 +554,6 @@ export class PeerScore {
 
   /**
    * Update all peer IPs to currently open connections
-   * @returns {void}
    */
   _updateIPs(): void {
     this.peerStats.forEach((pstats, id) => {

--- a/ts/tracer.ts
+++ b/ts/tracer.ts
@@ -17,16 +17,10 @@ export class IWantTracer {
    * Promises to deliver a message
    * Map per message id, per peer, promise expiration time
    */
-  promises: Map<string, Map<string, number>>
-  constructor() {
-    this.promises = new Map()
-  }
+  promises = new Map<string, Map<string, number>>()
 
   /**
    * Track a promise to deliver a message from a list of msgIds we are requesting
-   * @param {string} p peer id
-   * @param {string[]} msgIds
-   * @returns {void}
    */
   addPromise(p: string, msgIds: Uint8Array[]): void {
     // pick msgId randomly from the list
@@ -47,7 +41,6 @@ export class IWantTracer {
 
   /**
    * Returns the number of broken promises for each peer who didn't follow up on an IWANT request.
-   * @returns {Map<string, number>}
    */
   getBrokenPromises(): Map<string, number> {
     const now = Date.now()
@@ -74,8 +67,6 @@ export class IWantTracer {
 
   /**
    * Someone delivered a message, stop tracking promises for it
-   * @param {string} msgIdStr
-   * @returns {Promise<void>}
    */
   async deliverMessage(msgIdStr: string): Promise<void> {
     this.promises.delete(msgIdStr)
@@ -84,9 +75,6 @@ export class IWantTracer {
   /**
    * A message got rejected, so we can stop tracking promises and let the score penalty apply from invalid message delivery,
    * unless its an obviously invalid message.
-   * @param {string} msgIdStr
-   * @param {string} reason
-   * @returns {Promise<void>}
    */
   async rejectMessage(msgIdStr: string, reason: string): Promise<void> {
     switch (reason) {

--- a/ts/utils/create-gossip-rpc.ts
+++ b/ts/utils/create-gossip-rpc.ts
@@ -4,9 +4,6 @@ import { RPC, IRPC } from '../message/rpc'
 
 /**
  * Create a gossipsub RPC object
- * @param {Array<RPC.IMessage>} msgs
- * @param {Partial<RPC.IControlMessage>} control
- * @returns {IRPC}
  */
 export function createGossipRpc(msgs: RPC.IMessage[] = [], control: Partial<RPC.IControlMessage> = {}): IRPC {
   return {

--- a/ts/utils/shuffle.ts
+++ b/ts/utils/shuffle.ts
@@ -4,9 +4,6 @@
  * Pseudo-randomly shuffles an array
  *
  * Mutates the input array
- *
- * @param {Array} arr
- * @returns {Array}
  */
 export function shuffle<T>(arr: T[]): T[] {
   if (arr.length <= 1) {

--- a/ts/utils/time-cache.ts
+++ b/ts/utils/time-cache.ts
@@ -13,12 +13,11 @@ type CacheValue<T> = {
  * This gives 4x - 5x performance gain compared to npm TimeCache
  */
 export class SimpleTimeCache<T> {
-  private entries: Map<string, CacheValue<T>>
+  private entries = new Map<string, CacheValue<T>>()
   private validityMs: number
   private lastPruneTime = 0
 
   constructor(options: SimpleTimeCacheOpts) {
-    this.entries = new Map()
     this.validityMs = options.validityMs
 
     // allow negative validityMs so that this does not cache anything, spec test compliance.spec.js


### PR DESCRIPTION
JSDocs types are a legacy item from pre-Typescript implementation. Remove since they provide no additional information and can be out of sync