### PR TITLE
Fix floodPublish

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1060,7 +1060,7 @@ class Gossipsub extends Pubsub {
         return
       }
 
-      if (this._options.floodPublish && msg.from === this.peerId.toB58String()) {
+      if (this._options.floodPublish && msg.receivedFrom === this.peerId.toB58String()) {
         // flood-publish behavior
         // send to direct peers and _all_ peers meeting the publishThreshold
         peersInTopic.forEach((id) => {
@@ -1122,7 +1122,7 @@ class Gossipsub extends Pubsub {
     // Publish messages to peers
     const rpc = createGossipRpc([utils.normalizeOutRpcMessage(msg)])
     tosend.forEach((id) => {
-      if (id === msg.from) {
+      if (id === msg.receivedFrom) {
         return
       }
       this._sendRpc(id, rpc)

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1122,7 +1122,7 @@ class Gossipsub extends Pubsub {
     // Publish messages to peers
     const rpc = createGossipRpc([utils.normalizeOutRpcMessage(msg)])
     tosend.forEach((id) => {
-      if (id === msg.receivedFrom) {
+      if (id === msg.receivedFrom || id === msg.from) {
         return
       }
       this._sendRpc(id, rpc)


### PR DESCRIPTION
**Motivation**
+ We use "msg.from" in "_publish" method, however it's only available in "StrictSign" signature policy (lodestar/eth2 uses "StrictNoSign") https://github.com/libp2p/js-libp2p-interfaces/blob/libp2p-interfaces%404.0.4/packages/interfaces/src/pubsub/index.js#L637

**Description**
+ Use "receivedFrom" which is always available https://github.com/libp2p/js-libp2p-interfaces/blob/libp2p-interfaces%404.0.4/packages/interfaces/src/pubsub/index.js#L687
