### PR TITLE
chore: increase the default for seenTTL to match that of go-libp2p

### DIFF
--- a/ts/constants.ts
+++ b/ts/constants.ts
@@ -214,7 +214,7 @@ export const GossipsubIWantFollowupTime = 3 * second
 /**
  * Time in milliseconds to keep message ids in the seen cache
  */
-export const GossipsubSeenTTL = 30 * second
+export const GossipsubSeenTTL = 2 * minute
 
 export const TimeCacheDuration = 120 * 1000
 


### PR DESCRIPTION
In the go implementation of gossipsub, libp2p keeps a 2 minute long cache of recently seen pubsub messages so that the node won't forward on duplicate messages.  In the JS implementation the default seen cache ttl is only 30 seconds.  We have seen issues with duplicate pubsub messages (see https://github.com/libp2p/js-libp2p/issues/1043) and think this shorter cache ttl may be part of the problem.  In any case it would be good for the default behavior to be consistent between the javascript and go implementation