### PR TITLE
Do not apply P3 penalty if peers are pruned from topic mesh

### DIFF
--- a/ts/score/peer-score.ts
+++ b/ts/score/peer-score.ts
@@ -237,6 +237,7 @@ export class PeerScore {
       }
 
       tstats.inMesh = false
+      tstats.meshMessageDeliveriesActive = false
     })
 
     pstats.connected = false
@@ -279,6 +280,7 @@ export class PeerScore {
       tstats.meshFailurePenalty += deficit * deficit
     }
     tstats.inMesh = false
+    tstats.meshMessageDeliveriesActive = false
     this.scoreCache.set(id, { score: null, cacheUntil: 0 })
   }
 


### PR DESCRIPTION
**Motivation**
+ Part of the effort to investigate why P3 is applied a lot to peers

**Description**
+ Do not apply P3 penalty if peers are pruned from topic mesh (double checked with rust-libp2p)