### PR TITLE
Fix rpc.control metrics and reduce object creation

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1943,16 +1943,16 @@ export default class Gossipsub extends EventEmitter {
     }
 
     if (outRpc.control) {
-      outRpc.control.graft = outRpc.control.graft && outRpc.control.graft.concat(tograft)
-      outRpc.control.prune = outRpc.control.prune && outRpc.control.prune.concat(toprune)
+      outRpc.control.graft = outRpc.control.graft ? outRpc.control.graft.concat(tograft) : tograft
+      outRpc.control.prune = outRpc.control.prune ? outRpc.control.prune.concat(toprune) : toprune
     } else {
-      outRpc.control = { ihave: [], iwant: [], graft: tograft, prune: toprune }
+      outRpc.control = { graft: tograft, prune: toprune }
     }
   }
 
   private piggybackGossip(id: PeerIdStr, outRpc: IRPC, ihave: RPC.IControlIHave[]): void {
     if (!outRpc.control) {
-      outRpc.control = { ihave: [], iwant: [], graft: [], prune: [] }
+      outRpc.control = { ihave: [] }
     }
     outRpc.control.ihave = ihave
   }

--- a/ts/metrics.ts
+++ b/ts/metrics.ts
@@ -632,11 +632,15 @@ export function getMetrics(
       if (rpc.subscriptions) this.rpcSentSubscription.inc(rpc.subscriptions.length)
       if (rpc.messages) this.rpcSentMessage.inc(rpc.messages.length)
       if (rpc.control) {
-        this.rpcSentControl.inc(1)
-        if (rpc.control.ihave) this.rpcSentIHave.inc(rpc.control.ihave.length)
-        if (rpc.control.iwant) this.rpcSentIWant.inc(rpc.control.iwant.length)
-        if (rpc.control.graft) this.rpcSentGraft.inc(rpc.control.graft.length)
-        if (rpc.control.prune) this.rpcSentPrune.inc(rpc.control.prune.length)
+        const ihave = rpc.control.ihave ? rpc.control.ihave.length : 0
+        const iwant = rpc.control.iwant ? rpc.control.iwant.length : 0
+        const graft = rpc.control.graft ? rpc.control.graft.length : 0
+        const prune = rpc.control.prune ? rpc.control.prune.length : 0
+        if (ihave > 0) this.rpcSentIHave.inc(ihave)
+        if (iwant > 0) this.rpcSentIWant.inc(iwant)
+        if (graft > 0) this.rpcSentGraft.inc(graft)
+        if (prune > 0) this.rpcSentPrune.inc(prune)
+        if (ihave > 0 || iwant > 0 || graft > 0 || prune > 0) this.rpcSentControl.inc(1)
       }
     },
 

--- a/ts/utils/create-gossip-rpc.ts
+++ b/ts/utils/create-gossip-rpc.ts
@@ -5,15 +5,10 @@ import { RPC, IRPC } from '../message/rpc'
 /**
  * Create a gossipsub RPC object
  */
-export function createGossipRpc(messages: RPC.IMessage[] = [], control: Partial<RPC.IControlMessage> = {}): IRPC {
+export function createGossipRpc(messages: RPC.IMessage[] = [], control?: Partial<RPC.IControlMessage>): IRPC {
   return {
     subscriptions: [],
     messages,
-    control: {
-      ihave: control.ihave ?? [],
-      iwant: control.iwant ?? [],
-      graft: control.graft ?? [],
-      prune: control.prune ?? []
-    }
+    control
   }
 }


### PR DESCRIPTION
Metrics show that every RPC message we sent has a control in it, while only 0.02 received messages have a control. As shown with

```
rate(gossipsub_rpc_sent_control_total[$__rate_interval])
/
rate(gossipsub_rpc_sent_count_total[$__rate_interval])
```

The cause is that the control object is always created even when not necessary.

**Description**

- Create control object only when necessary
- Register control message when at least one array has at least one element