### PR TITLE
feat: add subpath exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,18 @@
   "exports": {
     ".": {
       "import": "./dist/src/index.js"
+    },
+    "./metrics": {
+      "import": "./dist/src/metrics.js"
+    },
+    "./message": {
+      "import": "./dist/src/message/index.js"
+    },
+    "./score": {
+      "import": "./dist/src/score/index.js"
+    },
+    "./types": {
+      "import": "./dist/src/types.js"
     }
   },
   "scripts": {

--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -1,0 +1,1 @@
+export * from './rpc.js'


### PR DESCRIPTION
While upgrading libp2p and gossipsub in lodestar, it seems we use certain useful things not exported from the root.

Add exports of metrics, message, score, and types for downstream users (like lodestar)