### PR TITLE
fix: opportunistic graft

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2465,7 +2465,9 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
           const backoff = this.backoff.get(topic)
           const peersToGraft = this.getRandomGossipPeers(topic, this.opts.opportunisticGraftPeers, (id) => {
             // filter out current mesh peers, direct peers, peers we are backing off, peers below or at threshold
-            return !peers.has(id) && !this.direct.has(id) && (!backoff || !backoff.has(id)) && getScore(id) > medianScore
+            return (
+              !peers.has(id) && !this.direct.has(id) && (!backoff || !backoff.has(id)) && getScore(id) > medianScore
+            )
           })
           peersToGraft.forEach((id) => {
             this.log('HEARTBEAT: Opportunistically graft peer %s on topic %s', id, topic)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2465,7 +2465,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
           const backoff = this.backoff.get(topic)
           const peersToGraft = this.getRandomGossipPeers(topic, this.opts.opportunisticGraftPeers, (id) => {
             // filter out current mesh peers, direct peers, peers we are backing off, peers below or at threshold
-            return peers.has(id) && !this.direct.has(id) && (!backoff || !backoff.has(id)) && getScore(id) > medianScore
+            return !peers.has(id) && !this.direct.has(id) && (!backoff || !backoff.has(id)) && getScore(id) > medianScore
           })
           peersToGraft.forEach((id) => {
             this.log('HEARTBEAT: Opportunistically graft peer %s on topic %s', id, topic)


### PR DESCRIPTION
**Motivation**
+ Correct opportunistic graft.

**Description**
+ Opportunistic graft happens once every 60 heartbeat, it's used to graft better peers to gradually improve the score of mesh peers
+ We want to graft peers that's not in the mesh, not peers that are already in the mesh