### PR TITLE
fix: finding outbound peers in heartbeat

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2440,7 +2440,13 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
           const backoff = this.backoff.get(topic)
           const newPeers = this.getRandomGossipPeers(topic, ineed, (id: string): boolean => {
             // filter our current mesh peers, direct peers, peers we are backing off, peers with negative score
-            return !peers.has(id) && !this.direct.has(id) && (!backoff || !backoff.has(id)) && getScore(id) >= 0
+            return (
+              !peers.has(id) &&
+              !this.direct.has(id) &&
+              (!backoff || !backoff.has(id)) &&
+              getScore(id) >= 0 &&
+              this.outbound.get(id) === true
+            )
           })
           newPeers.forEach((p) => graftPeer(p, InclusionReason.Outbound))
         }


### PR DESCRIPTION
**Motivation**
+ Fix the way we find more outbound peers during heartbeat

**Description**
+ Add the condition to find random outbound peers
+ Refer to https://github.com/libp2p/rust-libp2p/blob/fcc987e0f6dd82d0f702acd8b819b4f99a9fb26a/protocols/gossipsub/src/behaviour.rs#L2303