### PR TITLE
perf: improve heartbeat performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 docs/
 .nyc_output/coverage-final.json
 .vscode/settings.json
+benchmark_data/

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prepare": "npm run build",
     "pretest": "npm run build",
     "pretest:e2e": "npm run build",
-    "benchmark": "node ./node_modules/.bin/benchmark 'test/benchmark/time-cache.test.js' --local",
+    "benchmark": "node ./node_modules/.bin/benchmark 'dist/test/benchmark/*.test.js' --local",
     "test": "aegir test -f './dist/test/*.spec.js'",
     "test:e2e": "aegir test -f './dist/test/e2e/*.spec.js'",
     "test:node": "npm run test -- --target node",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2085,12 +2085,22 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
   }
 
   /**
+   * Emits gossip - Send IHAVE messages to a random set of gossip peers. This is applied to mesh
+   * and fanout peers
+   */
+  private emitGossip(peersToGossipByTopic: Map<string, Set<PeerIdStr>>): void {
+    for (const [topic, peersToGossip] of peersToGossipByTopic) {
+      this.doEmitGossip(topic, peersToGossip)
+    }
+  }
+
+  /**
    * Emits gossip to peers in a particular topic
    *
    * @param topic
-   * @param exclude - peers to exclude
+   * @param candidateToGossip - peers to gossip
    */
-  private emitGossip(topic: string, exclude: Set<string>): void {
+  private doEmitGossip(topic: string, candidateToGossip: Set<PeerIdStr>): void {
     const messageIDs = this.mcache.getGossipIDs(topic)
     if (!messageIDs.length) {
       return
@@ -2109,39 +2119,23 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     // First we collect the peers above gossipThreshold that are not in the exclude set
     // and then randomly select from that set
     // We also exclude direct peers, as there is no reason to emit gossip to them
-    const peersToGossip: string[] = []
-    const topicPeers = this.topics.get(topic)
-    if (!topicPeers) {
-      // no topic peers, no gossip
-      return
-    }
-    topicPeers.forEach((id) => {
-      const peerStreams = this.peers.get(id)
-      if (!peerStreams) {
-        return
-      }
-      if (
-        !exclude.has(id) &&
-        !this.direct.has(id) &&
-        hasGossipProtocol(peerStreams.protocol) &&
-        this.score.score(id) >= this.opts.scoreThresholds.gossipThreshold
-      ) {
-        peersToGossip.push(id)
-      }
-    })
 
+    if (!candidateToGossip.size) return
     let target = this.opts.Dlazy
-    const factor = constants.GossipsubGossipFactor * peersToGossip.length
+    const factor = constants.GossipsubGossipFactor * candidateToGossip.size
+    let peersToGossip: Set<PeerIdStr> | PeerIdStr[] = candidateToGossip
     if (factor > target) {
       target = factor
     }
-    if (target > peersToGossip.length) {
-      target = peersToGossip.length
+    if (target > peersToGossip.size) {
+      target = peersToGossip.size
     } else {
-      shuffle(peersToGossip)
+      // only shuffle if needed
+      peersToGossip = shuffle(Array.from(peersToGossip)).slice(0, target)
     }
+
     // Emit the IHAVE gossip to the selected peers up to the target
-    peersToGossip.slice(0, target).forEach((id) => {
+    peersToGossip.forEach((id) => {
       let peerMessageIDs = messageIDs
       if (messageIDs.length > constants.GossipsubMaxIHaveLength) {
         // shuffle and slice message IDs per peer so that we emit a different set for each peer
@@ -2264,7 +2258,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
   /**
    * Maintains the mesh and fanout maps in gossipsub.
    */
-  private async heartbeat(): Promise<void> {
+  public async heartbeat(): Promise<void> {
     const { D, Dlo, Dhi, Dscore, Dout, fanoutTTL } = this.opts
 
     this.heartbeatTicks++
@@ -2310,8 +2304,56 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     this.gossipTracer.prune()
     this.publishedMessageIds.prune()
 
+    /**
+     * Instead of calling getRandomGossipPeers multiple times to:
+     *   + get more mesh peers
+     *   + more outbound peers
+     *   + oppportunistic grafting
+     *   + emitGossip
+     *
+     * We want to loop through the topic peers only single time and perform different sets at different thresholds
+     * and do emit gossip with known peers to improve performance
+     */
+
+    const peersToGossipByTopic = new Map<string, Set<PeerIdStr>>()
     // maintain the mesh for topics we have joined
     this.mesh.forEach((peers, topic) => {
+      const peersInTopic = this.topics.get(topic)
+      let candidateMeshPeers: PeerIdStr[] = []
+      const peersToGossip = new Set<PeerIdStr>()
+      peersToGossipByTopic.set(topic, peersToGossip)
+
+      if (peersInTopic) {
+        const shuffledPeers = shuffle(Array.from(peersInTopic))
+        const backoff = this.backoff.get(topic)
+        for (const id of shuffledPeers) {
+          const peerStreams = this.peers.get(id)
+          if (peerStreams && hasGossipProtocol(peerStreams.protocol) && !peers.has(id) && !this.direct.has(id)) {
+            const score = getScore(id)
+            if ((!backoff || !backoff.has(id)) && score >= 0) candidateMeshPeers.push(id)
+            if (score >= this.opts.scoreThresholds.gossipThreshold) peersToGossip.add(id)
+          }
+        }
+      }
+
+      const meshPeersFromCandidates = (ineed: number, cond: (peer: PeerIdStr) => boolean): PeerIdStr[] => {
+        let count = 0
+        let index = 0
+        const newMeshPeers = []
+
+        while (count < ineed && index < candidateMeshPeers.length) {
+          if (cond(candidateMeshPeers[index])) {
+            newMeshPeers.push(candidateMeshPeers[index])
+            candidateMeshPeers.splice(index, 1)
+            count++
+          } else {
+            index++
+          }
+        }
+
+        return newMeshPeers
+      }
+
       // prune/graft helper functions (defined per topic)
       const prunePeer = (id: PeerIdStr, reason: ChurnReason): void => {
         this.log('HEARTBEAT: Remove mesh link to %s in %s', id, topic)
@@ -2320,6 +2362,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
         this.addBackoff(id, topic)
         // remove peer from mesh
         peers.delete(id)
+        if (getScore(id) >= this.opts.scoreThresholds.gossipThreshold) peersToGossip.add(id)
         this.metrics?.onRemoveFromMesh(topic, reason, 1)
         // add to toprune
         const topics = toprune.get(id)
@@ -2336,6 +2379,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
         this.score.graft(id, topic)
         // add peer to mesh
         peers.add(id)
+        peersToGossip.delete(id)
         this.metrics?.onAddToMesh(topic, reason, 1)
         // add to tograft
         const topics = tograft.get(id)
@@ -2361,14 +2405,13 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
 
       // do we have enough peers?
       if (peers.size < Dlo) {
-        const backoff = this.backoff.get(topic)
         const ineed = D - peers.size
-        const peersSet = this.getRandomGossipPeers(topic, ineed, (id) => {
-          // filter out mesh peers, direct peers, peers we are backing off, peers with negative score
-          return !peers.has(id) && !this.direct.has(id) && (backoff == null || !backoff.has(id)) && getScore(id) >= 0
-        })
+        const newMeshPeers = candidateMeshPeers.slice(0, ineed)
+        candidateMeshPeers = candidateMeshPeers.slice(ineed)
 
-        peersSet.forEach((p) => graftPeer(p, InclusionReason.NotEnough))
+        newMeshPeers.forEach((p) => {
+          graftPeer(p, InclusionReason.NotEnough)
+        })
       }
 
       // do we have to many peers?
@@ -2421,7 +2464,9 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
         }
 
         // prune the excess peers
-        peersArray.slice(D).forEach((p) => prunePeer(p, ChurnReason.Excess))
+        peersArray.slice(D).forEach((p) => {
+          prunePeer(p, ChurnReason.Excess)
+        })
       }
 
       // do we have enough outbound peers?
@@ -2437,18 +2482,11 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
         // if it's less than D_out, select some peers with outbound connections and graft them
         if (outbound < Dout) {
           const ineed = Dout - outbound
-          const backoff = this.backoff.get(topic)
-          const newPeers = this.getRandomGossipPeers(topic, ineed, (id: string): boolean => {
-            // filter our current mesh peers, direct peers, peers we are backing off, peers with negative score
-            return (
-              !peers.has(id) &&
-              !this.direct.has(id) &&
-              (!backoff || !backoff.has(id)) &&
-              getScore(id) >= 0 &&
-              this.outbound.get(id) === true
-            )
+          const newMeshPeers = meshPeersFromCandidates(ineed, (id) => this.outbound.get(id) === true)
+
+          newMeshPeers.forEach((p) => {
+            graftPeer(p, InclusionReason.Outbound)
           })
-          newPeers.forEach((p) => graftPeer(p, InclusionReason.Outbound))
         }
       }
 
@@ -2468,23 +2506,14 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
 
         // if the median score is below the threshold, select a better peer (if any) and GRAFT
         if (medianScore < this.opts.scoreThresholds.opportunisticGraftThreshold) {
-          const backoff = this.backoff.get(topic)
-          const peersToGraft = this.getRandomGossipPeers(topic, this.opts.opportunisticGraftPeers, (id) => {
-            // filter out current mesh peers, direct peers, peers we are backing off, peers below or at threshold
-            return (
-              !peers.has(id) && !this.direct.has(id) && (!backoff || !backoff.has(id)) && getScore(id) > medianScore
-            )
-          })
-          peersToGraft.forEach((id) => {
+          const ineed = this.opts.opportunisticGraftPeers
+          const newMeshPeers = meshPeersFromCandidates(ineed, (id) => getScore(id) > medianScore)
+          for (const id of newMeshPeers) {
             this.log('HEARTBEAT: Opportunistically graft peer %s on topic %s', id, topic)
             graftPeer(id, InclusionReason.Opportunistic)
-          })
+          }
         }
       }
-
-      // 2nd arg are mesh peers excluded from gossip. We have already pushed
-      // messages to them, so its redundant to gossip IHAVEs.
-      this.emitGossip(topic, peers)
     })
 
     // expire fanout for topics we haven't published to in a while
@@ -2506,24 +2535,35 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
         }
       })
 
+      const peersInTopic = this.topics.get(topic)
+      const candidateFanoutPeers = []
+      // the fanout map contains topics to which we are not subscribed.
+      const peersToGossip = new Set<PeerIdStr>()
+      peersToGossipByTopic.set(topic, peersToGossip)
+
+      if (peersInTopic) {
+        const shuffledPeers = shuffle(Array.from(peersInTopic))
+        for (const id of shuffledPeers) {
+          const peerStreams = this.peers.get(id)
+          if (peerStreams && hasGossipProtocol(peerStreams.protocol) && !fanoutPeers.has(id) && !this.direct.has(id)) {
+            const score = getScore(id)
+            if (score >= this.opts.scoreThresholds.publishThreshold) candidateFanoutPeers.push(id)
+            if (score >= this.opts.scoreThresholds.gossipThreshold) peersToGossip.add(id)
+          }
+        }
+      }
+
       // do we need more peers?
       if (fanoutPeers.size < D) {
         const ineed = D - fanoutPeers.size
-        const peersSet = this.getRandomGossipPeers(topic, ineed, (id) => {
-          // filter out existing fanout peers, direct peers, and peers with score above the publish threshold
-          return (
-            !fanoutPeers.has(id) && !this.direct.has(id) && getScore(id) >= this.opts.scoreThresholds.publishThreshold
-          )
-        })
-        peersSet.forEach((id) => {
+        candidateFanoutPeers.slice(0, ineed).forEach((id) => {
           fanoutPeers.add(id)
+          peersToGossip?.delete(id)
         })
       }
-
-      // 2nd arg are fanout peers excluded from gossip.
-      // We have already pushed messages to them, so its redundant to gossip IHAVEs
-      this.emitGossip(topic, fanoutPeers)
     })
+
+    this.emitGossip(peersToGossipByTopic)
 
     // send coalesced GRAFT/PRUNE messages (will piggyback gossip)
     await this.sendGraftPrune(tograft, toprune, noPX)

--- a/test/benchmark/index.test.ts
+++ b/test/benchmark/index.test.ts
@@ -1,0 +1,129 @@
+import { itBench, setBenchOpts } from "@dapplion/benchmark";
+import { GossipSub } from "../../src/index.js";
+import { connectPubsubNodes, createComponentsArray, denseConnect } from "../utils/create-pubsub.js";
+import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
+import { Components } from "@libp2p/interfaces/dist/src/components";
+import { awaitEvents, checkReceivedSubscriptions, checkReceivedSubscription } from "../utils/events.js";
+import { expect } from "chai";
+
+describe.only("heartbeat", function () {
+  this.timeout(0)
+  setBenchOpts({
+    maxMs: 200 * 1000,
+    minMs: 120 * 1000,
+    minRuns: 200,
+  })
+
+  const topic = 'foobar'
+  const numTopic = 70
+  const numPeers = 50
+  const numPeersPerTopic = 30
+  let numLoop = 0
+
+  const getTopic = (i: number): string => {
+    return topic + i
+  }
+
+  const getTopicPeerIndices = (topic: number): number[] => {
+    // peer 0 join all topics
+    const peers = [0]
+    // topic 0 starts from index 1
+    // topic 1 starts from index 2...
+    for (let i = 0; i < numPeersPerTopic - 1; i++) {
+      const peerIndex = (i + topic + 1) % numPeers
+      if (peerIndex !== 0) peers.push(peerIndex)
+    }
+    return peers
+  }
+
+  /**
+   * Star topology
+   *         peer 1
+   *        /
+   * peer 0  - peer 2
+   *        \
+   *         peer 3
+   *
+   * A topic contains peer 0 and some other peers, with numPeersPerTopic = 4
+   *
+   * |Topic|    Peers  |
+   * |-----|-----------|
+   * |  0  | 0, 1, 2, 3|
+   * |  1  | 0, 2, 3, 4|
+   */
+  itBench({
+    id: "heartbeat",
+    before: async () => {
+      const psubs = await createComponentsArray({
+        number: numPeers,
+        init: {
+          scoreParams: {
+            IPColocationFactorWeight: 0,
+          },
+          floodPublish: true,
+          // TODO: why we need to configure this low score
+          // probably we should tweak topic score params
+          // is that why we don't have mesh peers?
+          scoreThresholds: {
+            gossipThreshold: -10,
+            publishThreshold: -100,
+            graylistThreshold: -1000
+          },
+        }
+      })
+
+      // build the star
+      await Promise.all(psubs.slice(1).map((ps) => connectPubsubNodes(psubs[0], ps)))
+      await Promise.all(psubs.map((ps) => awaitEvents(ps.getPubSub(), 'gossipsub:heartbeat', 2)))
+
+      await denseConnect(psubs)
+
+      // make sure psub 0 has `numPeers - 1` peers
+      expect(psubs[0].getPubSub().getPeers().length).to.be.gte(numPeers - 1, `peer 0 should have at least ${numPeers - 1} peers`)
+
+      const peerIds = psubs.map((psub) => psub.getPeerId().toString())
+      for (let topicIndex = 0; topicIndex < numTopic; topicIndex++) {
+        const topic = getTopic(topicIndex)
+        psubs.forEach((ps) => ps.getPubSub().subscribe(topic))
+        const peerIndices = getTopicPeerIndices(topicIndex)
+        const peerIdsOnTopic = peerIndices.map((peerIndex) => peerIds[peerIndex])
+        // peer 0 see all subscriptions from other
+        const subscription = checkReceivedSubscriptions(psubs[0], peerIdsOnTopic, topic)
+        // other peers should see the subsription from peer 0 to prevent PublishError.InsufficientPeers error
+        const otherSubscriptions = peerIndices.slice(1).map((peerIndex) => psubs[peerIndex]).map((psub) => checkReceivedSubscription(psub, peerIds[0], topic, 0))
+        peerIndices.map((peerIndex) => psubs[peerIndex].getPubSub().subscribe(topic))
+        await Promise.all([subscription, ...otherSubscriptions])
+      }
+
+
+      // wait for heartbeats to build mesh
+      await Promise.all(psubs.map(async (ps) => await awaitEvents(ps.getPubSub(), 'gossipsub:heartbeat', 3)))
+
+
+      // make sure psubs 0 have at least 10 topic peers and 4 mesh peers for each topic
+      for (let i = 0; i < numTopic; i++) {
+        expect((psubs[0].getPubSub() as GossipSub).getSubscribers(getTopic(i)).length).to.be.gte(10, `psub 0: topic ${i} does not have enough topic peers`)
+
+        expect((psubs[0].getPubSub() as GossipSub).getMeshPeers(getTopic(i)).length).to.be.gte(4, `psub 0: topic ${i} does not have enough mesh peers`)
+      }
+
+      return psubs
+    },
+    beforeEach: async (psubs) => {
+      numLoop ++
+      const msg = `its not a flooooood ${numLoop}`
+      const promises = []
+      for (let topicIndex = 0; topicIndex < numTopic; topicIndex++) {
+        for (const peerIndex of getTopicPeerIndices(topicIndex)) {
+          promises.push(psubs[peerIndex].getPubSub().publish(getTopic(topicIndex), uint8ArrayFromString(psubs[peerIndex].getPeerId().toString() + msg)))
+        }
+      }
+      await Promise.all(promises)
+
+      return psubs[0]
+    },
+    fn: (firstPsub: Components) => {
+      (firstPsub.getPubSub() as GossipSub).heartbeat()
+    },
+  })
+});

--- a/test/utils/events.ts
+++ b/test/utils/events.ts
@@ -1,0 +1,82 @@
+import { Components } from '@libp2p/interfaces/dist/src/components';
+import type { Message, SubscriptionChangeData } from '@libp2p/interfaces/pubsub'
+import type { EventEmitter } from '@libp2p/interfaces/events'
+import { expect } from 'chai';
+import pWaitFor from 'p-wait-for';
+import { GossipSub, GossipsubEvents } from "../../src/index.js";
+
+// TODO: share with go-gossipsub
+export const checkReceivedSubscription = (
+  node: Components,
+  peerIdStr: string,
+  topic: string,
+  peerIdx: number,
+  timeout = 1000
+) =>
+  new Promise<void>((resolve, reject) => {
+    const event = 'subscription-change'
+    let cb: (evt: CustomEvent<SubscriptionChangeData>) => void
+    const t = setTimeout(() => reject(`Not received subscriptions of psub ${peerIdx}, topic ${topic}`), timeout)
+    cb = (evt) => {
+      const { peerId, subscriptions } = evt.detail
+
+      // console.log('@@@ in test received subscriptions from peer id', peerId.toString())
+      if (peerId.toString() === peerIdStr && subscriptions[0].topic === topic && subscriptions[0].subscribe === true) {
+        clearTimeout(t)
+        node.getPubSub().removeEventListener(event, cb)
+        if (
+          Array.from(node.getPubSub().getSubscribers(topic) || [])
+            .map((p) => p.toString())
+            .includes(peerIdStr)
+        ) {
+          resolve()
+        } else {
+          reject(Error('topics should include the peerId'))
+        }
+      }
+    }
+    node.getPubSub().addEventListener(event, cb)
+  })
+
+export const checkReceivedSubscriptions = async (node: Components, peerIdStrs: string[], topic: string, timeout = 5000) => {
+  const recvPeerIdStrs = peerIdStrs.filter((peerIdStr) => peerIdStr !== node.getPeerId().toString())
+  const promises = recvPeerIdStrs.map(
+    async (peerIdStr, idx) => await checkReceivedSubscription(node, peerIdStr, topic, idx, timeout)
+  )
+  await Promise.all(promises)
+  for (const str of recvPeerIdStrs) {
+    expect(Array.from(node.getPubSub().getSubscribers(topic)).map((p) => p.toString())).to.include(str)
+  }
+  await pWaitFor(() => {
+    return recvPeerIdStrs.every((peerIdStr) => {
+      const peerStream = (node.getPubSub() as GossipSub).peers.get(peerIdStr)
+
+      return peerStream?.isWritable
+    })
+  })
+}
+
+export const awaitEvents = async <Events = GossipsubEvents>(
+  emitter: EventEmitter<Events>,
+  event: keyof Events,
+  number: number,
+  timeout = 30000
+) => {
+  return new Promise<void>((resolve, reject) => {
+    let cb: () => void
+    let counter = 0
+    const t = setTimeout(() => {
+      emitter.removeEventListener(event, cb)
+      reject(new Error(`${counter} of ${number} '${event}' events received after ${timeout}ms`))
+    }, timeout)
+    cb = () => {
+      counter++
+      if (counter >= number) {
+        clearTimeout(t)
+        emitter.removeEventListener(event, cb)
+        resolve()
+      }
+    }
+    emitter.addEventListener(event, cb)
+  })
+}


### PR DESCRIPTION
**Motivation**
+ heartbeat() takes time as shown in #256 

**Description**
- Right now in heartbeat we call `getRandomGossipPeers` multiple times to:
  - get more mesh peers
  - more outbound peers
  - opportunistic grafting
  - emit gossip

we should loop through the topics peers only 1 time, it's an almost 2x performance as shown in the `heartbeat()` benchmark

- part of #256