### PR TITLE
feat: add msgIdToStrFn option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -396,7 +396,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     // By default, gossipsub only provide a browser friendly function to convert Uint8Array message id to string.
     this.msgIdToStrFn = options.msgIdToStrFn ?? messageIdToString
 
-    this.mcache = options.messageCache || new MessageCache(opts.mcacheGossip, this.msgIdToStrFn, opts.mcacheLength)
+    this.mcache = options.messageCache || new MessageCache(opts.mcacheGossip, opts.mcacheLength, this.msgIdToStrFn)
 
     if (options.dataTransform) {
       this.dataTransform = options.dataTransform

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,9 +276,6 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
    */
   private readonly fastMsgIdFn: FastMsgIdFn | undefined
 
-  /**
-   * By default, gossipsub only provide a browser friendly function to convert Uint8Array message id to string.
-   */
   private readonly msgIdToStrFn: MsgIdToStrFn
 
   /** Maps fast message-id to canonical message-id */
@@ -396,6 +393,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
       this.fastMsgIdCache = new SimpleTimeCache<string>({ validityMs: opts.seenTTL })
     }
 
+    // By default, gossipsub only provide a browser friendly function to convert Uint8Array message id to string.
     this.msgIdToStrFn = options.msgIdToStrFn ?? messageIdToString
 
     this.mcache = options.messageCache || new MessageCache(opts.mcacheGossip, this.msgIdToStrFn, opts.mcacheLength)

--- a/src/message-cache.ts
+++ b/src/message-cache.ts
@@ -40,8 +40,8 @@ export class MessageCache {
      * message in the cache.
      */
     private readonly gossip: number,
-    msgIdToStrFn: MsgIdToStrFn,
-    historyCapacity: number
+    historyCapacity: number,
+    msgIdToStrFn: MsgIdToStrFn
   ) {
     this.msgIdToStrFn = msgIdToStrFn
     for (let i = 0; i < historyCapacity; i++) {

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -1,5 +1,4 @@
-import { messageIdToString } from './utils/index.js'
-import { MsgIdStr, PeerIdStr, RejectReason } from './types.js'
+import { MsgIdStr, MsgIdToStrFn, PeerIdStr, RejectReason } from './types.js'
 import type { Metrics } from './metrics.js'
 
 /**
@@ -23,7 +22,11 @@ export class IWantTracer {
   private readonly requestMsByMsg = new Map<MsgIdStr, number>()
   private readonly requestMsByMsgExpire: number
 
-  constructor(private readonly gossipsubIWantFollowupMs: number, private readonly metrics: Metrics | null) {
+  constructor(
+    private readonly gossipsubIWantFollowupMs: number,
+    private readonly msgIdToStrFn: MsgIdToStrFn,
+    private readonly metrics: Metrics | null
+  ) {
     this.requestMsByMsgExpire = 10 * gossipsubIWantFollowupMs
   }
 
@@ -42,7 +45,7 @@ export class IWantTracer {
     // pick msgId randomly from the list
     const ix = Math.floor(Math.random() * msgIds.length)
     const msgId = msgIds[ix]
-    const msgIdStr = messageIdToString(msgId)
+    const msgIdStr = this.msgIdToStrFn(msgId)
 
     let expireByPeer = this.promises.get(msgIdStr)
     if (!expireByPeer) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,12 @@ export interface AddrInfo {
 export type FastMsgIdFn = (msg: RPC.Message) => string
 
 /**
+ * By default, gossipsub only provide a browser friendly function to convert Uint8Array message id to string.
+ * Application could use this option to provide a more efficient function.
+ */
+export type MsgIdToStrFn = (msgId: Uint8Array) => string
+
+/**
  * Compute spec'ed msg-id. Used for IHAVE / IWANT messages
  */
 export interface MsgIdFn {

--- a/src/utils/messageIdToString.ts
+++ b/src/utils/messageIdToString.ts
@@ -3,7 +3,6 @@ import { toString } from 'uint8arrays/to-string'
 
 /**
  * Browser friendly function to convert Uint8Array message id to base64 string.
- * Do not use this function directly unless in test.
  */
 export function messageIdToString(msgId: Uint8Array): string {
   return toString(msgId, 'base64')

--- a/src/utils/messageIdToString.ts
+++ b/src/utils/messageIdToString.ts
@@ -1,10 +1,17 @@
 import { fromString } from 'uint8arrays/from-string'
 import { toString } from 'uint8arrays/to-string'
 
+/**
+ * Browser friendly function to convert Uint8Array message id to base64 string.
+ * Do not use this function directly unless in test.
+ */
 export function messageIdToString(msgId: Uint8Array): string {
   return toString(msgId, 'base64')
 }
 
+/**
+ * Browser friendly function to convert base64 message id string to Uint8Array
+ */
 export function messageIdFromString(msgId: string): Uint8Array {
   return fromString(msgId, 'base64')
 }

--- a/test/message-cache.spec.ts
+++ b/test/message-cache.spec.ts
@@ -7,7 +7,7 @@ import { getMsgId } from './utils/index.js'
 import type { RPC } from '../src/message/rpc.js'
 
 describe('Testing Message Cache Operations', () => {
-  const messageCache = new MessageCache(3, 5)
+  const messageCache = new MessageCache(3, messageIdToString, 5)
   const testMessages: RPC.Message[] = []
 
   before(async () => {

--- a/test/message-cache.spec.ts
+++ b/test/message-cache.spec.ts
@@ -7,7 +7,7 @@ import { getMsgId } from './utils/index.js'
 import type { RPC } from '../src/message/rpc.js'
 
 describe('Testing Message Cache Operations', () => {
-  const messageCache = new MessageCache(3, messageIdToString, 5)
+  const messageCache = new MessageCache(3, 5, messageIdToString)
   const testMessages: RPC.Message[] = []
 
   before(async () => {

--- a/test/tracer.spec.ts
+++ b/test/tracer.spec.ts
@@ -4,12 +4,13 @@ import { IWantTracer } from '../src/tracer.js'
 import * as constants from '../src/constants.js'
 import { makeTestMessage, getMsgId, getMsgIdStr } from './utils/index.js'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
+import { messageIdToString } from '../src/utils/messageIdToString.js'
 
 describe('IWantTracer', () => {
   it('should track broken promises', async function () {
     // tests that unfulfilled promises are tracked correctly
     this.timeout(6000)
-    const t = new IWantTracer(constants.GossipsubIWantFollowupTime, null)
+    const t = new IWantTracer(constants.GossipsubIWantFollowupTime, messageIdToString, null)
     const peerA = (await createEd25519PeerId()).toString()
     const peerB = (await createEd25519PeerId()).toString()
 
@@ -37,7 +38,7 @@ describe('IWantTracer', () => {
   it('should track unbroken promises', async function () {
     // like above, but this time we deliver messages to fullfil the promises
     this.timeout(6000)
-    const t = new IWantTracer(constants.GossipsubIWantFollowupTime, null)
+    const t = new IWantTracer(constants.GossipsubIWantFollowupTime, messageIdToString, null)
     const peerA = (await createEd25519PeerId()).toString()
     const peerB = (await createEd25519PeerId()).toString()
 


### PR DESCRIPTION
**Motivation**
- Lodestar would like to use `Buffer.from` to convert Uint8Array message id to string as it's more efficient as found in https://github.com/ChainSafe/lodestar/issues/3446

**Description**
- Provide `msgIdToStrFn` option so that application can provide its own implementation
- Closes #269 