### PR TITLE
feat: remove messageIdFromString

### DIFF
--- a/src/message-cache.ts
+++ b/src/message-cache.ts
@@ -1,9 +1,7 @@
 import type { RPC } from './message/rpc.js'
-import type { MsgIdStr, PeerIdStr, TopicStr, MsgIdToStrFn } from './types.js'
-import { messageIdFromString } from './utils/messageIdToString.js'
+import type { MessageId, MsgIdStr, PeerIdStr, TopicStr, MsgIdToStrFn } from './types.js'
 
-export interface CacheEntry {
-  msgId: Uint8Array
+export type CacheEntry = MessageId & {
   topic: TopicStr
 }
 
@@ -57,7 +55,8 @@ export class MessageCache {
    * Adds a message to the current window and the cache
    * Returns true if the message is not known and is inserted in the cache
    */
-  put(msgIdStr: MsgIdStr, msg: RPC.Message): boolean {
+  put(messageId: MessageId, msg: RPC.Message): boolean {
+    const { msgIdStr } = messageId
     // Don't add duplicate entries to the cache.
     if (this.msgs.has(msgIdStr)) {
       return false
@@ -70,8 +69,7 @@ export class MessageCache {
       iwantCounts: new Map()
     })
 
-    const msgId = messageIdFromString(msgIdStr)
-    this.history[0].push({ msgId: msgId, topic: msg.topic })
+    this.history[0].push({ ...messageId, topic: msg.topic })
 
     return true
   }
@@ -153,8 +151,7 @@ export class MessageCache {
   shift(): void {
     const last = this.history[this.history.length - 1]
     last.forEach((entry) => {
-      const msgIdStr = this.msgIdToStrFn(entry.msgId)
-      this.msgs.delete(msgIdStr)
+      this.msgs.delete(entry.msgIdStr)
     })
 
     this.history.pop()

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,10 @@ export enum MessageStatus {
   valid = 'valid'
 }
 
+/**
+ * Store both Uint8Array and string message id so that we don't have to convert data between the two.
+ * See https://github.com/ChainSafe/js-libp2p-gossipsub/pull/274
+ */
 export type MessageId = {
   msgId: Uint8Array
   msgIdStr: MsgIdStr

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,11 @@ export enum MessageStatus {
   valid = 'valid'
 }
 
+export type MessageId = {
+  msgId: Uint8Array
+  msgIdStr: MsgIdStr
+}
+
 /**
  * Typesafe conversion of MessageAcceptance -> RejectReason. TS ensures all values covered
  */

--- a/src/utils/messageIdToString.ts
+++ b/src/utils/messageIdToString.ts
@@ -1,4 +1,3 @@
-import { fromString } from 'uint8arrays/from-string'
 import { toString } from 'uint8arrays/to-string'
 
 /**
@@ -6,11 +5,4 @@ import { toString } from 'uint8arrays/to-string'
  */
 export function messageIdToString(msgId: Uint8Array): string {
   return toString(msgId, 'base64')
-}
-
-/**
- * Browser friendly function to convert base64 message id string to Uint8Array
- */
-export function messageIdFromString(msgId: string): Uint8Array {
-  return fromString(msgId, 'base64')
 }

--- a/test/message-cache.spec.ts
+++ b/test/message-cache.spec.ts
@@ -5,6 +5,14 @@ import { MessageCache } from '../src/message-cache.js'
 import * as utils from '@libp2p/pubsub/utils'
 import { getMsgId } from './utils/index.js'
 import type { RPC } from '../src/message/rpc.js'
+import { MessageId } from '../src/types.js'
+
+const toMessageId = (msgId: Uint8Array): MessageId => {
+  return {
+    msgId,
+    msgIdStr: messageIdToString(msgId)
+  }
+}
 
 describe('Testing Message Cache Operations', () => {
   const messageCache = new MessageCache(3, 5, messageIdToString)
@@ -25,7 +33,7 @@ describe('Testing Message Cache Operations', () => {
     }
 
     for (let i = 0; i < 10; i++) {
-      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i])
     }
   })
 
@@ -50,7 +58,7 @@ describe('Testing Message Cache Operations', () => {
   it('Shift message cache', async () => {
     messageCache.shift()
     for (let i = 10; i < 20; i++) {
-      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i])
     }
 
     for (let i = 0; i < 20; i++) {
@@ -74,22 +82,22 @@ describe('Testing Message Cache Operations', () => {
 
     messageCache.shift()
     for (let i = 20; i < 30; i++) {
-      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i])
     }
 
     messageCache.shift()
     for (let i = 30; i < 40; i++) {
-      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i])
     }
 
     messageCache.shift()
     for (let i = 40; i < 50; i++) {
-      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i])
     }
 
     messageCache.shift()
     for (let i = 50; i < 60; i++) {
-      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i])
     }
 
     expect(messageCache.msgs.size).to.equal(50)


### PR DESCRIPTION
**Motivation**
- `messageIdFromString()` is not cheap, it takes 1.64 % of cpu time as in one of lodestar beacon node
<img width="1169" alt="Screen Shot 2022-06-10 at 15 33 31" src="https://user-images.githubusercontent.com/10568965/173025576-ce8ff17f-df33-4ad7-aec2-47651129e6bb.png">

- we always have Uint8Array message id in all of our flows, we convert to string and we have to convert it back which is a redundancy
- `mcache`: we receive string msgId in `put()`, convert it to Uint8Array to cache and convert it to string again in `shift()` which is another redundancy

**Description**
- Introduce MessageId `msgId: Uint8Array; msgIdStr: MsgIdStr` with the convention
  - msgId: Uint8Array
  - msgIdStr: string representation of msgId
  - messageId: new MessageId type containing both msgId and msgIdStr
- Cache MessageId in mcache
- remove `messageIdFromString()` completely
- Part of #271

**Memory cost**
- An mcache of 5000 items takes 1MB more, 20000 items take 4MB more
- As monitored in a lodestar node subscribing to all subnets, mcache size is only 400 so it's cheap enough
