### PR TITLE
fix: only gossip validated messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -928,7 +928,8 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
         this.gossipTracer.deliverMessage(validationResult.messageId.msgIdStr)
 
         // Add the message to our memcache
-        this.mcache.put(validationResult.messageId, rpcMsg)
+        // if no validation is required, mark the message as validated
+        this.mcache.put(validationResult.messageId, rpcMsg, !this.opts.asyncValidation)
 
         // Dispatch the message to the user if we are subscribed to the topic
         if (this.subscriptions.has(rpcMsg.topic)) {
@@ -1878,7 +1879,8 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     // If the message isn't a duplicate and we have sent it to some peers add it to the
     // duplicate cache and memcache.
     this.seenCache.put(msgIdStr)
-    this.mcache.put({ msgId, msgIdStr }, rawMsg)
+    // all published messages are valid
+    this.mcache.put({ msgId, msgIdStr }, rawMsg, true)
 
     // If the message is anonymous or has a random author add it to the published message ids cache.
     this.publishedMessageIds.put(msgIdStr)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2098,8 +2098,9 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
    * Emits gossip - Send IHAVE messages to a random set of gossip peers
    */
   private emitGossip(peersToGossipByTopic: Map<string, Set<PeerIdStr>>): void {
+    const gossipIDsByTopic = this.mcache.getGossipIDs(new Set(peersToGossipByTopic.keys()))
     for (const [topic, peersToGossip] of peersToGossipByTopic) {
-      this.doEmitGossip(topic, peersToGossip)
+      this.doEmitGossip(topic, peersToGossip, gossipIDsByTopic.get(topic) ?? [])
     }
   }
 
@@ -2109,9 +2110,9 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
    * We also exclude direct peers, as there is no reason to emit gossip to them
    * @param topic
    * @param candidateToGossip - peers to gossip
+   * @param messageIDs - message ids to gossip
    */
-  private doEmitGossip(topic: string, candidateToGossip: Set<PeerIdStr>): void {
-    const messageIDs = this.mcache.getGossipIDs(topic)
+  private doEmitGossip(topic: string, candidateToGossip: Set<PeerIdStr>, messageIDs: Uint8Array[]): void {
     if (!messageIDs.length) {
       return
     }

--- a/src/message-cache.ts
+++ b/src/message-cache.ts
@@ -55,7 +55,7 @@ export class MessageCache {
    * Adds a message to the current window and the cache
    * Returns true if the message is not known and is inserted in the cache
    */
-  put(messageId: MessageId, msg: RPC.Message): boolean {
+  put(messageId: MessageId, msg: RPC.Message, validated = false): boolean {
     const { msgIdStr } = messageId
     // Don't add duplicate entries to the cache.
     if (this.msgs.has(msgIdStr)) {
@@ -64,7 +64,7 @@ export class MessageCache {
 
     this.msgs.set(msgIdStr, {
       message: msg,
-      validated: false,
+      validated,
       originatingPeers: new Set(),
       iwantCounts: new Map()
     })
@@ -117,9 +117,7 @@ export class MessageCache {
     const msgIdsByTopic = new Map<string, Uint8Array[]>()
     for (let i = 0; i < this.gossip; i++) {
       this.history[i].forEach((entry) => {
-        // TODO: no need to convert to string again
-        // see https://github.com/ChainSafe/js-libp2p-gossipsub/pull/274
-        const msg = this.msgs.get(this.msgIdToStrFn(entry.msgId))
+        const msg = this.msgs.get(entry.msgIdStr)
         if (msg && msg.validated && topics.has(entry.topic)) {
           let msgIds = msgIdsByTopic.get(entry.topic)
           if (!msgIds) {

--- a/test/message-cache.spec.ts
+++ b/test/message-cache.spec.ts
@@ -38,7 +38,7 @@ describe('Testing Message Cache Operations', () => {
     }
 
     for (let i = 0; i < 10; i++) {
-      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i], true)
     }
   })
 
@@ -63,7 +63,7 @@ describe('Testing Message Cache Operations', () => {
   it('Shift message cache', async () => {
     messageCache.shift()
     for (let i = 10; i < 20; i++) {
-      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i], true)
     }
 
     for (let i = 0; i < 20; i++) {
@@ -87,22 +87,22 @@ describe('Testing Message Cache Operations', () => {
 
     messageCache.shift()
     for (let i = 20; i < 30; i++) {
-      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i], true)
     }
 
     messageCache.shift()
     for (let i = 30; i < 40; i++) {
-      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i], true)
     }
 
     messageCache.shift()
     for (let i = 40; i < 50; i++) {
-      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i], true)
     }
 
     messageCache.shift()
     for (let i = 50; i < 60; i++) {
-      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i], true)
     }
 
     expect(messageCache.msgs.size).to.equal(50)
@@ -147,12 +147,9 @@ describe('Testing Message Cache Operations', () => {
     expect(gossipIDs.length).to.be.equal(0)
 
     for (let i = 10; i < 20; i++) {
-      const msgIdStr = messageIdToString(getMsgId(testMessages[i]))
-      messageCache.put(msgIdStr, testMessages[i])
       // 5 last messages are not validated
-      if (i < 15) {
-        messageCache.validate(msgIdStr)
-      }
+      const validated = i < 15
+      messageCache.put(toMessageId(getMsgId(testMessages[i])), testMessages[i], validated)
     }
 
     gossipIDs = getGossipIDs(messageCache, topic)

--- a/test/message-cache.spec.ts
+++ b/test/message-cache.spec.ts
@@ -17,6 +17,11 @@ const toMessageId = (msgId: Uint8Array): MessageId => {
 describe('Testing Message Cache Operations', () => {
   const messageCache = new MessageCache(3, 5, messageIdToString)
   const testMessages: RPC.Message[] = []
+  const topic = 'test'
+  const getGossipIDs = (mcache: MessageCache, topic: string): Uint8Array[] => {
+    const gossipIDsByTopic = mcache.getGossipIDs(new Set([topic]))
+    return gossipIDsByTopic.get(topic) ?? []
+  }
 
   before(async () => {
     const makeTestMessage = (n: number): RPC.Message => {
@@ -24,7 +29,7 @@ describe('Testing Message Cache Operations', () => {
         from: new Uint8Array(0),
         data: uint8ArrayFromString(n.toString()),
         seqno: uint8ArrayFromString(utils.randomSeqno().toString(16).padStart(16, '0'), 'base16'),
-        topic: 'test'
+        topic
       }
     }
 
@@ -46,12 +51,12 @@ describe('Testing Message Cache Operations', () => {
   })
 
   it('Get GossipIDs', () => {
-    const gossipIDs = messageCache.getGossipIDs('test')
+    const gossipIDs = getGossipIDs(messageCache, topic)
     expect(gossipIDs.length).to.equal(10)
 
     for (let i = 0; i < 10; i++) {
       const messageID = getMsgId(testMessages[i])
-      expect(messageID).to.deep.equal(gossipIDs[i])
+      expect(messageID).to.deep.equal(gossipIDs![i])
     }
   })
 
@@ -67,7 +72,7 @@ describe('Testing Message Cache Operations', () => {
       expect(message).to.equal(testMessages[i])
     }
 
-    let gossipIDs = messageCache.getGossipIDs('test')
+    let gossipIDs = getGossipIDs(messageCache, topic)
     expect(gossipIDs.length).to.equal(20)
 
     for (let i = 0; i < 10; i++) {
@@ -114,7 +119,7 @@ describe('Testing Message Cache Operations', () => {
       expect(message).to.equal(testMessages[i])
     }
 
-    gossipIDs = messageCache.getGossipIDs('test')
+    gossipIDs = getGossipIDs(messageCache, topic)
     expect(gossipIDs.length).to.equal(30)
 
     for (let i = 0; i < 10; i++) {
@@ -130,6 +135,31 @@ describe('Testing Message Cache Operations', () => {
     for (let i = 20; i < 30; i++) {
       const messageID = getMsgId(testMessages[10 + i])
       expect(messageID).to.deep.equal(gossipIDs[i])
+    }
+  })
+
+  it('should not gossip not-validated message ids', () => {
+    let gossipIDs = getGossipIDs(messageCache, topic)
+    while (gossipIDs.length > 0) {
+      messageCache.shift()
+      gossipIDs = getGossipIDs(messageCache, topic)
+    }
+    expect(gossipIDs.length).to.be.equal(0)
+
+    for (let i = 10; i < 20; i++) {
+      const msgIdStr = messageIdToString(getMsgId(testMessages[i]))
+      messageCache.put(msgIdStr, testMessages[i])
+      // 5 last messages are not validated
+      if (i < 15) {
+        messageCache.validate(msgIdStr)
+      }
+    }
+
+    gossipIDs = getGossipIDs(messageCache, topic)
+    expect(gossipIDs.length).to.be.equal(5)
+    // only validate the new gossip ids
+    for (let i = 0; i < 5; i++) {
+      expect(gossipIDs[i]).to.deep.equal(getMsgId(testMessages[i + 10]), 'incorrect gossip message id ' + i)
     }
   })
 })


### PR DESCRIPTION
**Motivation**
- when getting gossip message ids, we should loop through mcache history 1 time
- we should only gossip validated messages

**Description**
- Loop through mcache history 1 time for all topics
- when `asyncValidation` option is undefined or false, messages are consider validated
- when publishing messages, they are considered validated

Closes #271

TODO: wait for https://github.com/ChainSafe/js-libp2p-gossipsub/pull/274