### PR TITLE
perf: improve metric performance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -898,7 +898,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
    * May forward to all peers in the mesh.
    */
   private async handleReceivedMessage(from: PeerId, rpcMsg: RPC.Message): Promise<void> {
-    this.metrics?.onMsgRecvPreValidation(rpcMsg.topic)
+    // this.metrics?.onMsgRecvPreValidation(rpcMsg.topic)
 
     const validationResult = await this.validateReceivedMessage(from, rpcMsg)
 
@@ -1135,7 +1135,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     const score = this.score.score(id)
     if (score < this.opts.scoreThresholds.gossipThreshold) {
       this.log('IHAVE: ignoring peer %s with score below threshold [ score = %d ]', id, score)
-      this.metrics?.ihaveRcvIgnored.inc({ reason: IHaveIgnoreReason.LowScore })
+      this.metrics?.ihaveRcvIgnored.inc(IHaveIgnoreReason.LowScore)
       return []
     }
 
@@ -1148,14 +1148,14 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
         id,
         peerhave
       )
-      this.metrics?.ihaveRcvIgnored.inc({ reason: IHaveIgnoreReason.MaxIhave })
+      this.metrics?.ihaveRcvIgnored.inc(IHaveIgnoreReason.MaxIhave)
       return []
     }
 
     const iasked = this.iasked.get(id) ?? 0
     if (iasked >= constants.GossipsubMaxIHaveLength) {
       this.log('IHAVE: peer %s has already advertised too many messages (%d); ignoring', id, iasked)
-      this.metrics?.ihaveRcvIgnored.inc({ reason: IHaveIgnoreReason.MaxIasked })
+      this.metrics?.ihaveRcvIgnored.inc(IHaveIgnoreReason.MaxIasked)
       return []
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -898,7 +898,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
    * May forward to all peers in the mesh.
    */
   private async handleReceivedMessage(from: PeerId, rpcMsg: RPC.Message): Promise<void> {
-    // this.metrics?.onMsgRecvPreValidation(rpcMsg.topic)
+    this.metrics?.onMsgRecvPreValidation(rpcMsg.topic)
 
     const validationResult = await this.validateReceivedMessage(from, rpcMsg)
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -850,10 +850,10 @@ export function getMetrics(
     },
 
     // 0.9%
-    // onMsgRecvPreValidation(topicStr: TopicStr): void {
-    //   const topic = this.toTopic(topicStr)
-    //   this.msgReceivedPreValidation.inc({ topic }, 1)
-    // },
+    onMsgRecvPreValidation(topicStr: TopicStr): void {
+      const topic = this.toTopic(topicStr)
+      this.msgReceivedPreValidation.inc({ topic }, 1)
+    },
 
     // 0.93%
     onMsgRecvResult(topicStr: TopicStr, status: MessageStatus): void {


### PR DESCRIPTION
**Motivation**
- `gauge.inc()` takes 2.45% cpu time which is > 2 / 3 `runHeartbeat()` cpu time

**Description**
- `gauge.inc()` will hash the label objects and push to Map every time we call it
- so we we write some cached gauge metric class to only do that when scrape
  - gauge has no label: use `NoLabelCachedGauge`, this gives 7x improvement
  - gauge has 1 label: use `OneLabelCachedGauge`, this gives 1.2x improvement
  - gauge has 2 labels: use `TwoLabelCachedGauge`, this gives 2.5x improvement
- also remove unnecessary gauge metric