### PR TITLE
feat: allow configuring stream limits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,16 @@ export interface GossipsubOpts extends GossipsubOptsSpec, PubSubInit {
   /** Prefix tag for debug logs */
   debugName?: string
 
+  /**
+   * Specify the maximum number of inbound gossipsub protocol
+   * streams that are allowed to be open concurrently
+   */
   maxInboundStreams?: number
+
+  /**
+   * Specify the maximum number of outbound gossipsub protocol
+   * streams that are allowed to be open concurrently
+   */
   maxOutboundStreams?: number
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -453,8 +453,8 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
       scoreCacheValidityMs: opts.heartbeatInterval
     })
 
-    this.maxInboundStreams = options.maxInboundStreams ?? 32
-    this.maxOutboundStreams = options.maxOutboundStreams ?? 128
+    this.maxInboundStreams = options.maxInboundStreams
+    this.maxOutboundStreams = options.maxOutboundStreams
   }
 
   getPeers(): PeerId[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -330,8 +330,8 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
   readonly opts: Required<GossipOptions>
   private readonly metrics: Metrics | null
   private status: GossipStatus = { code: GossipStatusCode.stopped }
-  private maxInboundStreams: number
-  private maxOutboundStreams: number
+  private maxInboundStreams?: number
+  private maxOutboundStreams?: number
 
   private heartbeatTimer: {
     _intervalId: ReturnType<typeof setInterval> | undefined


### PR DESCRIPTION
The registrar defaults to only allowing 1x inbound and 1x outbound stream per protocol so allow configuring more than that.

I've plucked some defaults out of the air, these will need tuning to make sure they're not too restrictive or permissive.