### PR TITLE
feat: tweak stream handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,10 +78,13 @@
     "@libp2p/peer-record": "^2.0.0",
     "@libp2p/pubsub": "^3.0.0",
     "@libp2p/topology": "^3.0.0",
+    "abortable-iterator": "^4.0.2",
     "denque": "^1.5.0",
     "err-code": "^3.0.1",
     "iso-random-stream": "^2.0.2",
+    "it-length-prefixed": "^7.0.1",
     "it-pipe": "^2.0.3",
+    "it-pushable": "^3.0.0",
     "multiformats": "^9.6.4",
     "protons-runtime": "^1.0.4",
     "uint8arrays": "^3.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1602,9 +1602,13 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
    */
   private async connect(id: PeerIdStr): Promise<void> {
     this.log('Initiating connection with %s', id)
-    const connection = await this.components.getConnectionManager().openConnection(peerIdFromString(id))
-    await connection.newStream(this.multicodecs)
-    // TODO: what happens to the stream?
+    const peerId = peerIdFromString(id)
+    const connection = await this.components.getConnectionManager().openConnection(peerId)
+    for (const multicodec of this.multicodecs) {
+      for (const topology of this.components.getRegistrar().getTopologies(multicodec)) {
+        topology.onConnect(peerId, connection)
+      }
+    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
 import { pipe } from 'it-pipe'
-import type { Connection } from '@libp2p/interface-connection'
+import type { Connection, Stream } from '@libp2p/interface-connection'
 import { RecordEnvelope } from '@libp2p/peer-record'
 import { peerIdFromBytes, peerIdFromString } from '@libp2p/peer-id'
 import { Logger, logger } from '@libp2p/logger'
 import { createTopology } from '@libp2p/topology'
-import { PeerStreams } from '@libp2p/pubsub/peer-streams'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import { CustomEvent, EventEmitter } from '@libp2p/interfaces/events'
 import { toString as uint8ArrayToString } from 'uint8arrays/to-string'
@@ -76,6 +75,8 @@ import {
 } from '@libp2p/interface-pubsub'
 import type { IncomingStreamData } from '@libp2p/interface-registrar'
 import { removeFirstNItemsFromSet, removeItemsFromSet } from './utils/set.js'
+import { pushable } from 'it-pushable'
+import { InboundStream, OutboundStream } from './stream.js'
 
 // From 'bl' library
 interface BufferList {
@@ -197,7 +198,12 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
 
   // State
 
-  public readonly peers = new Map<PeerIdStr, PeerStreams>()
+  public readonly peers = new Set<PeerIdStr>()
+  public readonly streamsInbound = new Map<PeerIdStr, InboundStream>()
+  public readonly streamsOutbound = new Map<PeerIdStr, OutboundStream>()
+
+  /** Ensures outbound streams are created sequentially */
+  private outboundInflightQueue = pushable<{ peerId: PeerId; connection: Connection }>({ objectMode: true })
 
   /** Direct peers */
   public readonly direct = new Set<PeerIdStr>()
@@ -472,6 +478,15 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
 
     this.publishConfig = await getPublishConfigFromPeerId(this.globalSignaturePolicy, this.components.getPeerId())
 
+    // Create the outbound inflight queue
+    // This ensures that outbound stream creation happens sequentially
+    this.outboundInflightQueue = pushable({ objectMode: true })
+    pipe(this.outboundInflightQueue, async (source) => {
+      for await (const { peerId, connection } of source) {
+        await this.createOutboundStream(peerId, connection)
+      }
+    }).catch((e) => this.log.error('outbound inflight queue error', e))
+
     // set direct peer addresses in the address book
     await Promise.all(
       this.opts.directPeers.map(async (p) => {
@@ -524,8 +539,6 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
       hearbeatStartMs: Date.now() + constants.GossipsubHeartbeatInitialDelay
     }
 
-    this.log('started')
-
     this.score.start()
     // connect to direct peers
     this.directPeerInitial = setTimeout(() => {
@@ -537,6 +550,8 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
           this.log(err)
         })
     }, constants.GossipsubDirectConnectInitialDelay)
+
+    this.log('started')
   }
 
   /**
@@ -557,9 +572,17 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     const registrar = this.components.getRegistrar()
     registrarTopologyIds.forEach((id) => registrar.unregister(id))
 
-    for (const peerStreams of this.peers.values()) {
-      peerStreams.close()
+    this.outboundInflightQueue.end()
+
+    for (const outboundStream of this.streamsOutbound.values()) {
+      outboundStream.close()
     }
+    this.streamsOutbound.clear()
+
+    for (const inboundStream of this.streamsInbound.values()) {
+      inboundStream.close()
+    }
+    this.streamsInbound.clear()
 
     this.peers.clear()
     this.subscriptions.clear()
@@ -604,38 +627,24 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     }
 
     const peerId = connection.remotePeer
-    // TODO remove this non-nullish assertion after https://github.com/libp2p/js-libp2p-interfaces/pull/265 is incorporated
-    const peer = this.addPeer(peerId, stream.stat.protocol!, stream.stat.direction)
-    const inboundStream = peer.attachInboundStream(stream)
-
-    this.pipePeerReadStream(peerId, inboundStream).catch((err) => this.log(err))
+    // add peer to router
+    this.addPeer(peerId, connection.stat.direction)
+    // create inbound stream
+    this.createInboundStream(peerId, stream)
+    // attempt to create outbound stream
+    this.outboundInflightQueue.push({ peerId, connection })
   }
 
   /**
    * Registrar notifies an established connection with pubsub protocol
    */
-  private onPeerConnected(peerId: PeerId, conn: Connection): void {
+  private onPeerConnected(peerId: PeerId, connection: Connection): void {
     if (!this.isStarted()) {
       return
     }
 
-    this.log('topology peer connected %p %s', peerId, conn.stat.direction)
-
-    Promise.resolve().then(async () => {
-      try {
-        const stream = await conn.newStream(this.multicodecs)
-        // TODO remove this non-nullish assertion after https://github.com/libp2p/js-libp2p-interfaces/pull/265 is incorporated
-        const peer = this.addPeer(peerId, stream.stat.protocol!, conn.stat.direction)
-        await peer.attachOutboundStream(stream)
-      } catch (err) {
-        this.log(err)
-      }
-
-      // Immediately send my own subscriptions to the newly established conn
-      if (this.subscriptions.size > 0) {
-        this.sendSubscriptions(peerId.toString(), Array.from(this.subscriptions), true)
-      }
-    })
+    this.addPeer(peerId, connection.stat.direction)
+    this.outboundInflightQueue.push({ peerId, connection })
   }
 
   /**
@@ -646,67 +655,133 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     this.removePeer(peerId)
   }
 
+  private async createOutboundStream(peerId: PeerId, connection: Connection): Promise<void> {
+    if (!this.isStarted()) {
+      return
+    }
+
+    const id = peerId.toString()
+
+    if (!this.peers.has(id)) {
+      return
+    }
+
+    // TODO make this behavior more robust
+    // This behavior is different than for inbound streams
+    // If an outbound stream already exists, don't create a new stream
+    if (this.streamsOutbound.has(id)) {
+      return
+    }
+
+    try {
+      const stream = new OutboundStream(await connection.newStream(this.multicodecs), (e) =>
+        this.log.error('outbound pipe error', e)
+      )
+
+      this.log('create outbound stream %p', peerId)
+
+      this.streamsOutbound.set(id, stream)
+
+      const protocol = stream.protocol
+      if (protocol === constants.FloodsubID) {
+        this.floodsubPeers.add(id)
+      }
+      this.metrics?.peersPerProtocol.inc({ protocol }, 1)
+
+      // Immediately send own subscriptions via the newly attached stream
+      if (this.subscriptions.size > 0) {
+        this.log('send subscriptions to', id)
+        this.sendSubscriptions(id, Array.from(this.subscriptions), true)
+      }
+    } catch (e) {
+      this.log.error('createOutboundStream error', e)
+    }
+  }
+
+  private async createInboundStream(peerId: PeerId, stream: Stream): Promise<void> {
+    if (!this.isStarted()) {
+      return
+    }
+
+    const id = peerId.toString()
+
+    if (!this.peers.has(id)) {
+      return
+    }
+
+    // TODO make this behavior more robust
+    // This behavior is different than for outbound streams
+    // If a peer initiates a new inbound connection
+    // we assume that one is the new canonical inbound stream
+    const priorInboundStream = this.streamsInbound.get(id)
+    if (priorInboundStream !== undefined) {
+      this.log('replacing existing inbound steam %s', id)
+      priorInboundStream.close()
+    }
+
+    this.log('create inbound stream %s', id)
+
+    const inboundStream = new InboundStream(stream)
+    this.streamsInbound.set(id, inboundStream)
+
+    this.pipePeerReadStream(peerId, inboundStream.source).catch((err) => this.log(err))
+  }
+
   /**
    * Add a peer to the router
    */
-  private addPeer(peerId: PeerId, protocol: string, direction: ConnectionDirection): PeerStreams {
-    const peerIdStr = peerId.toString()
-    let peerStreams = this.peers.get(peerIdStr)
+  private addPeer(peerId: PeerId, direction: ConnectionDirection): void {
+    const id = peerId.toString()
 
-    // If peer streams already exists, do nothing
-    if (peerStreams === undefined) {
-      // else create a new peer streams
+    if (!this.peers.has(id)) {
       this.log('new peer %p', peerId)
 
-      peerStreams = new PeerStreams({
-        id: peerId,
-        protocol
-      })
+      this.peers.add(id)
 
-      this.peers.set(peerIdStr, peerStreams)
-      peerStreams.addEventListener('close', () => this.removePeer(peerId))
+      // Add to peer scoring
+      this.score.addPeer(id)
+      // track the connection direction. Don't allow to unset outbound
+      if (!this.outbound.has(id)) {
+        this.outbound.set(id, direction === 'outbound')
+      }
     }
-
-    // Add to peer scoring
-    this.score.addPeer(peerIdStr)
-    if (protocol === constants.FloodsubID) {
-      this.floodsubPeers.add(peerIdStr)
-    }
-    this.metrics?.peersPerProtocol.inc({ protocol }, 1)
-
-    // track the connection direction. Don't allow to unset outbound
-    if (!this.outbound.get(peerIdStr)) {
-      this.outbound.set(peerIdStr, direction === 'outbound')
-    }
-
-    return peerStreams
   }
 
   /**
    * Removes a peer from the router
    */
-  private removePeer(peerId: PeerId): PeerStreams | undefined {
+  private removePeer(peerId: PeerId): void {
     const id = peerId.toString()
-    const peerStreams = this.peers.get(id)
 
-    if (peerStreams != null) {
-      this.metrics?.peersPerProtocol.inc({ protocol: peerStreams.protocol }, -1)
+    if (!this.peers.has(id)) {
+      return
+    }
 
-      // delete peer streams. Must delete first to prevent re-entracy loop in .close()
-      this.log('delete peer %p', peerId)
-      this.peers.delete(id)
+    // delete peer
+    this.log('delete peer %p', peerId)
+    this.peers.delete(id)
 
-      // close peer streams
-      peerStreams.close()
+    const outboundStream = this.streamsOutbound.get(id)
+    const inboundStream = this.streamsInbound.get(id)
 
-      // remove peer from topics map
-      for (const peers of this.topics.values()) {
-        peers.delete(id)
-      }
+    if (outboundStream) {
+      this.metrics?.peersPerProtocol.inc({ protocol: outboundStream.protocol }, -1)
+    }
+
+    // close streams
+    outboundStream?.close()
+    inboundStream?.close()
+
+    // remove streams
+    this.streamsOutbound.delete(id)
+    this.streamsInbound.delete(id)
+
+    // remove peer from topics map
+    for (const peers of this.topics.values()) {
+      peers.delete(id)
     }
 
     // Remove this peer from the mesh
-    // eslint-disable-next-line no-unused-vars
     for (const [topicStr, peers] of this.mesh) {
       if (peers.delete(id) === true) {
         this.metrics?.onRemoveFromMesh(topicStr, ChurnReason.Dc, 1)
@@ -714,7 +789,6 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     }
 
     // Remove this peer from the fanout
-    // eslint-disable-next-line no-unused-vars
     for (const peers of this.fanout.values()) {
       peers.delete(id)
     }
@@ -732,8 +806,6 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     this.score.removePeer(id)
 
     this.acceptFromWhitelist.delete(id)
-
-    return peerStreams
   }
 
   // API METHODS
@@ -1462,8 +1534,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
   private async directConnect(): Promise<void> {
     const toconnect: string[] = []
     this.direct.forEach((id) => {
-      const peer = this.peers.get(id)
-      if (!peer || !peer.isWritable) {
+      if (!this.streamsOutbound.has(id)) {
         toconnect.push(id)
       }
     })
@@ -2010,8 +2081,8 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
    * Send an rpc object to a peer
    */
   private sendRpc(id: PeerIdStr, rpc: RPC): boolean {
-    const peerStreams = this.peers.get(id)
-    if (!peerStreams || !peerStreams.isWritable) {
+    const outboundStream = this.streamsOutbound.get(id)
+    if (!outboundStream) {
       this.log(`Cannot send RPC to ${id} as there is no open stream to it available`)
       return false
     }
@@ -2031,7 +2102,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     }
 
     const rpcBytes = RPC.encode(rpc)
-    peerStreams.write(rpcBytes)
+    outboundStream.push(rpcBytes)
 
     this.metrics?.onRpcSent(rpc, rpcBytes.length)
 
@@ -2189,7 +2260,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
    */
   private async makePrune(id: PeerIdStr, topic: string, doPX: boolean): Promise<RPC.ControlPrune> {
     this.score.prune(id, topic)
-    if (this.peers.get(id)!.protocol === constants.GossipsubIDv10) {
+    if (this.streamsOutbound.get(id)!.protocol === constants.GossipsubIDv10) {
       // Gossipsub v1.0 -- no backoff, the peer won't be able to parse it anyway
       return {
         topicID: topic,
@@ -2335,7 +2406,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
         const shuffledPeers = shuffle(Array.from(peersInTopic))
         const backoff = this.backoff.get(topic)
         for (const id of shuffledPeers) {
-          const peerStreams = this.peers.get(id)
+          const peerStreams = this.streamsOutbound.get(id)
           if (peerStreams && hasGossipProtocol(peerStreams.protocol) && !peers.has(id) && !this.direct.has(id)) {
             const score = getScore(id)
             if ((!backoff || !backoff.has(id)) && score >= 0) candidateMeshPeers.add(id)
@@ -2539,7 +2610,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
       if (peersInTopic) {
         const shuffledPeers = shuffle(Array.from(peersInTopic))
         for (const id of shuffledPeers) {
-          const peerStreams = this.peers.get(id)
+          const peerStreams = this.streamsOutbound.get(id)
           if (peerStreams && hasGossipProtocol(peerStreams.protocol) && !fanoutPeers.has(id) && !this.direct.has(id)) {
             const score = getScore(id)
             if (score >= this.opts.scoreThresholds.publishThreshold) candidateFanoutPeers.push(id)
@@ -2597,7 +2668,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     // that also pass the filter function
     let peers: string[] = []
     peersInTopic.forEach((id) => {
-      const peerStreams = this.peers.get(id)
+      const peerStreams = this.streamsOutbound.get(id)
       if (!peerStreams) {
         return
       }

--- a/src/score/peer-score.ts
+++ b/src/score/peer-score.ts
@@ -323,7 +323,7 @@ export class PeerScore {
     // defensive check that this is the first delivery trace -- delivery status should be unknown
     if (drec.status !== DeliveryRecordStatus.unknown) {
       log(
-        'unexpected delivery: message from %s was first seen %s ago and has delivery status %d',
+        'unexpected delivery: message from %s was first seen %s ago and has delivery status %s',
         from,
         now - drec.firstSeen,
         DeliveryRecordStatus[drec.status]

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,0 +1,56 @@
+import { Stream } from '@libp2p/interface-connection'
+import { abortableSource } from 'abortable-iterator'
+import { pipe } from 'it-pipe'
+import { pushable, Pushable } from 'it-pushable'
+import { encode, decode } from 'it-length-prefixed'
+
+export class OutboundStream {
+  private readonly rawStream: Stream
+  private readonly pushable: Pushable<Uint8Array>
+  private readonly closeController: AbortController
+
+  constructor(rawStream: Stream, errCallback: (e: Error) => void) {
+    this.rawStream = rawStream
+    this.pushable = pushable()
+    this.closeController = new AbortController()
+
+    pipe(
+      abortableSource(this.pushable, this.closeController.signal, { returnOnAbort: true }),
+      encode(),
+      this.rawStream
+    ).catch(errCallback)
+  }
+
+  get protocol(): string {
+    // TODO remove this non-nullish assertion after https://github.com/libp2p/js-libp2p-interfaces/pull/265 is incorporated
+    return this.rawStream.stat.protocol!
+  }
+
+  push(data: Uint8Array): void {
+    this.pushable.push(data)
+  }
+
+  close(): void {
+    this.closeController.abort()
+    this.rawStream.close()
+  }
+}
+
+export class InboundStream {
+  public readonly source: AsyncIterable<Uint8Array>
+
+  private readonly rawStream: Stream
+  private readonly closeController: AbortController
+
+  constructor(rawStream: Stream) {
+    this.rawStream = rawStream
+    this.closeController = new AbortController()
+
+    this.source = abortableSource(pipe(this.rawStream, decode()), this.closeController.signal, { returnOnAbort: true })
+  }
+
+  close(): void {
+    this.closeController.abort()
+    this.rawStream.close()
+  }
+}

--- a/test/2-nodes.spec.ts
+++ b/test/2-nodes.spec.ts
@@ -385,7 +385,7 @@ describe('2 nodes', () => {
     })
 
     it("nodes don't have peers after stopped", async () => {
-      stop(nodes)
+      await stop(...nodes)
       expect(nodes[0].getPubSub().getPeers()).to.be.empty()
       expect(nodes[1].getPubSub().getPeers()).to.be.empty()
     })

--- a/test/e2e/go-gossipsub.spec.ts
+++ b/test/e2e/go-gossipsub.spec.ts
@@ -992,6 +992,8 @@ describe('go-libp2p-pubsub gossipsub tests', function () {
       checkReceivedSubscription(psubs[2], peerIdStrs[1], topic, 1, 10000)
     ]
     await psubs[1].getConnectionManager().closeConnections(psubs[2].getPeerId())
+    // TODO remove when https://github.com/libp2p/js-libp2p-interfaces/pull/268 is merged
+    await psubs[2].getConnectionManager().closeConnections(psubs[1].getPeerId())
 
     await Promise.all(psubs.map((ps) => awaitEvents(ps.getPubSub(), 'gossipsub:heartbeat', 5)))
     await Promise.all(connectPromises)

--- a/test/gossip.spec.ts
+++ b/test/gossip.spec.ts
@@ -118,9 +118,7 @@ describe('gossip', () => {
     ).to.include(peerB, "did not know about peerB's subscription to topic")
 
     // should be able to send them messages
-    expect((nodeA.getPubSub() as GossipSub).peers.get(peerB)).to.have.property(
-      'isWritable',
-      true,
+    expect((nodeA.getPubSub() as GossipSub).streamsOutbound.has(peerB)).to.be.true(
       'nodeA did not have connection open to peerB'
     )
 

--- a/test/signature-policy.spec.ts
+++ b/test/signature-policy.spec.ts
@@ -10,7 +10,7 @@ import {
   createComponentsArray
 } from './utils/create-pubsub.js'
 
-describe.only('signature policy', () => {
+describe('signature policy', () => {
   describe('strict-sign', () => {
     const numNodes = 3
     let nodes: Components[]

--- a/test/utils/create-pubsub.ts
+++ b/test/utils/create-pubsub.ts
@@ -41,7 +41,11 @@ export const createComponents = async (opts: CreateComponentsOpts): Promise<Comp
 export const createComponentsArray = async (
   opts: CreateComponentsOpts & { number: number; connected?: boolean } = { number: 1, connected: true }
 ): Promise<Components[]> => {
-  const output = await Promise.all(Array.from({ length: opts.number }).map(async () => createComponents(opts)))
+  const output = await Promise.all(
+    Array.from({ length: opts.number }).map(async (_, i) =>
+      createComponents({ ...opts, init: { ...opts.init, debugName: `libp2p:gossipsub:${i}` } })
+    )
+  )
 
   if (opts.connected) {
     await connectAllPubSubNodes(output)

--- a/test/utils/create-pubsub.ts
+++ b/test/utils/create-pubsub.ts
@@ -59,7 +59,11 @@ export const connectPubsubNodes = async (componentsA: Components, componentsB: C
 
   const connection = await componentsA.getConnectionManager().openConnection(componentsB.getPeerId())
 
-  connection.newStream(Array.from(multicodecs))
+  for (const multicodec of multicodecs) {
+    for (const topology of componentsA.getRegistrar().getTopologies(multicodec)) {
+      topology.onConnect(componentsB.getPeerId(), connection)
+    }
+  }
 }
 
 export const connectAllPubSubNodes = async (components: Components[]): Promise<void> => {

--- a/test/utils/events.ts
+++ b/test/utils/events.ts
@@ -55,9 +55,7 @@ export const checkReceivedSubscriptions = async (
   }
   await pWaitFor(() => {
     return recvPeerIdStrs.every((peerIdStr) => {
-      const peerStream = (node.getPubSub() as GossipSub).peers.get(peerIdStr)
-
-      return peerStream?.isWritable
+      return (node.getPubSub() as GossipSub).streamsOutbound.has(peerIdStr)
     })
   })
 }


### PR DESCRIPTION
The ovararching problem with our previous approach is that we're too carefree about managing streams for this protocol.
Specific problems include:
- creating multiple duplicate outbound streams.
- relying solely on a topology to trigger an outbound stream.

Creation and tracking of new streams is tweaked:
- Add an outbound stream queue
This used to ensure that outbound streams are created sequentially.
This stops multiple duplicate streams from being created for a single peer.
- Attempt to create an outbound stream when an inbound stream is created.
This allows us to connect to peers that haven't yet been registered by the topology but want to connect to us.
- Remove `PeerStreams` usage in favor of managing inbound/outbound streams separately
`PeerStreams` works, but obscures some lingering issues. It's also quite inflexible and annoying to modify it since `PeerStreams` implements an interface in `@libp2p/interface-pubsub`.