### PR TITLE
feat: remove unnecessary direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "abortable-iterator": "^4.0.2",
     "denque": "^1.5.0",
     "err-code": "^3.0.1",
-    "iso-random-stream": "^2.0.2",
     "it-length-prefixed": "^7.0.1",
     "it-pipe": "^2.0.3",
     "it-pushable": "^3.0.0",

--- a/src/utils/buildRawMessage.ts
+++ b/src/utils/buildRawMessage.ts
@@ -1,7 +1,7 @@
-import { randomBytes } from 'iso-random-stream'
 import { concat as uint8ArrayConcat } from 'uint8arrays/concat'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { unmarshalPublicKey } from '@libp2p/crypto/keys'
+import { randomBytes } from '@libp2p/crypto'
 import { peerIdFromBytes } from '@libp2p/peer-id'
 import type { PublicKey } from '@libp2p/interface-keys'
 import type { PeerId } from '@libp2p/interface-peer-id'


### PR DESCRIPTION
Remove `iso-random-stream` direct dependency, use `randomBytes` API from
`@libp2p/crypto` instead.

`iso-random-stream` brings in `buffer` dependency which then needs to be
polyfilled when targeting the browser.

Related: https://github.com/libp2p/js-libp2p-crypto/pull/262