### PR TITLE
chore: migrate to it-length-prefixed 8.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,11 +80,12 @@
     "abortable-iterator": "^4.0.2",
     "denque": "^1.5.0",
     "err-code": "^3.0.1",
-    "it-length-prefixed": "^7.0.1",
+    "it-length-prefixed": "^8.0.2",
     "it-pipe": "^2.0.3",
     "it-pushable": "^3.0.0",
     "multiformats": "^9.6.4",
     "protobufjs": "^6.11.2",
+    "uint8arraylist": "^2.0.0",
     "uint8arrays": "^3.0.0"
   },
   "devDependencies": {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -3,6 +3,7 @@ import { abortableSource } from 'abortable-iterator'
 import { pipe } from 'it-pipe'
 import { pushable, Pushable } from 'it-pushable'
 import { encode, decode } from 'it-length-prefixed'
+import { Uint8ArrayList } from 'uint8arraylist'
 
 export class OutboundStream {
   private readonly rawStream: Stream
@@ -37,7 +38,7 @@ export class OutboundStream {
 }
 
 export class InboundStream {
-  public readonly source: AsyncIterable<Uint8Array>
+  public readonly source: AsyncIterable<Uint8ArrayList>
 
   private readonly rawStream: Stream
   private readonly closeController: AbortController


### PR DESCRIPTION
**Motivation**
- `it-length-prefixed` yields no-copy data, it should help improve performance

**Description**
- Migrate to `it-length-prefixed` 8.0.2
- Remove the `BufferList` assumption since `it-length-prefixed` yields Uint8ArrayList consistently