### PR TITLE
fix: handle closing outbound stream

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2736,6 +2736,8 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     metrics.cacheSize.set({ cache: 'fanout' }, this.fanout.size)
     // Bounded by peer
     metrics.cacheSize.set({ cache: 'peers' }, this.peers.size)
+    metrics.cacheSize.set({ cache: 'streamsOutbound' }, this.streamsOutbound.size)
+    metrics.cacheSize.set({ cache: 'streamsInbound' }, this.streamsInbound.size)
     metrics.cacheSize.set({ cache: 'acceptFromWhitelist' }, this.acceptFromWhitelist.size)
     metrics.cacheSize.set({ cache: 'gossip' }, this.gossip.size)
     metrics.cacheSize.set({ cache: 'control' }, this.control.size)

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -33,6 +33,8 @@ export class OutboundStream {
 
   close(): void {
     this.closeController.abort()
+    // similar to pushable.end() but clear the internal buffer
+    this.pushable.return()
     this.rawStream.close()
   }
 }


### PR DESCRIPTION
**Motivation**
- The `pushable` inside `Outbound` stream keeps some internal buffers inside, we need to clear them when closing the `OutboundStream` or it becomes a memory leak if the raw stream is also closed
<img width="1452" alt="Screen Shot 2022-08-08 at 10 22 55" src="https://user-images.githubusercontent.com/10568965/183332036-3aca936f-0ba6-4307-a63a-c5195f922178.png">

**Description**
- End the `pushable` by calling `return()` method when closing outbound stram - it's similar to `end()` but also clearing the internal buffers inside the `pushable`
- Track the inbound/outbound streams in the metrics
