### PR TITLE
fix: freeze libp2p dependencies to get through build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,12 +69,12 @@
     "@libp2p/interface-connection": "^2.0.0",
     "@libp2p/interface-keys": "^1.0.2",
     "@libp2p/interface-peer-id": "^1.0.2",
-    "@libp2p/interface-pubsub": "^1.0.1",
-    "@libp2p/interface-registrar": "^2.0.0",
+    "@libp2p/interface-pubsub": "1.0.4",
+    "@libp2p/interface-registrar": "2.0.2",
     "@libp2p/interfaces": "^3.0.2",
     "@libp2p/logger": "^2.0.0",
     "@libp2p/peer-id": "^1.1.13",
-    "@libp2p/peer-record": "^2.0.0",
+    "@libp2p/peer-record": "2.0.0",
     "@libp2p/pubsub": "^3.0.0",
     "@libp2p/topology": "^3.0.0",
     "abortable-iterator": "^4.0.2",
@@ -95,7 +95,7 @@
     "@libp2p/interface-mocks": "^3.0.1",
     "@libp2p/interface-pubsub-compliance-tests": "^1.0.4",
     "@libp2p/peer-id-factory": "^1.0.13",
-    "@libp2p/peer-store": "^3.0.0",
+    "@libp2p/peer-store": "3.1.0",
     "@multiformats/multiaddr": "^10.2.0",
     "@types/node": "^17.0.21",
     "@typescript-eslint/eslint-plugin": "^3.0.2",
@@ -127,6 +127,17 @@
     "ts-node": "^10.7.0",
     "ts-sinon": "^2.0.2",
     "util": "^0.12.3"
+  },
+  "overrides": {
+    "@libp2p/interface-connection": "^2.0.0",
+    "@libp2p/interface-pubsub": "1.0.4",
+    "@libp2p/interface-connection-manager": "1.0.2",
+    "@libp2p/interface-stream-muxer": "2.0.1",
+    "@libp2p/interface-transport": "1.0.2",
+    "@libp2p/interface-peer-store": "1.2.0"
+  },
+  "engines": {
+    "npm": ">=8.7.0"
   },
   "contributors": [
     "Cayman <caymannava@gmail.com>",


### PR DESCRIPTION
**Motivation**
- Some libp2p dependencies have breaking changes but were published as hot fix so got build error in this repo

**Description**
- Freeze dependencies in this version
- Will use updated dependencies based on `js-libp2p` release