### PR TITLE
feat: add option to limit OutboundStream buffer size

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -151,6 +151,12 @@ export interface GossipsubOpts extends GossipsubOptsSpec, PubSubInit {
    * streams that are allowed to be open concurrently
    */
   maxOutboundStreams?: number
+
+  /**
+   * Specify max buffer size in bytes for OutboundStream.
+   * If full it will throw and reject sending any more data.
+   */
+  maxOutboundBufferSize?: number
 }
 
 export interface GossipsubMessage {
@@ -691,8 +697,10 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     }
 
     try {
-      const stream = new OutboundStream(await connection.newStream(this.multicodecs), (e) =>
-        this.log.error('outbound pipe error', e)
+      const stream = new OutboundStream(
+        await connection.newStream(this.multicodecs),
+        (e) => this.log.error('outbound pipe error', e),
+        { maxBufferSize: this.opts.maxOutboundBufferSize }
       )
 
       this.log('create outbound stream %p', peerId)


### PR DESCRIPTION
- See https://github.com/ChainSafe/js-libp2p-gossipsub/issues/321

Add option `maxOutboundBufferSize` to bound the max size of the underlying FIFO queue in OutboundStream.

Closes https://github.com/ChainSafe/js-libp2p-gossipsub/issues/321