### PR TITLE
feat: only gossip validated messages

### DIFF
--- a/test/message-cache.spec.ts
+++ b/test/message-cache.spec.ts
@@ -35,7 +35,7 @@ describe('Testing Message Cache Operations', () => {
     }
 
     for (let i = 0; i < 10; i++) {
-      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i], true)
     }
   })
 
@@ -60,7 +60,7 @@ describe('Testing Message Cache Operations', () => {
   it('Shift message cache', async () => {
     messageCache.shift()
     for (let i = 10; i < 20; i++) {
-      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i], true)
     }
 
     for (let i = 0; i < 20; i++) {
@@ -84,22 +84,22 @@ describe('Testing Message Cache Operations', () => {
 
     messageCache.shift()
     for (let i = 20; i < 30; i++) {
-      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i], true)
     }
 
     messageCache.shift()
     for (let i = 30; i < 40; i++) {
-      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i], true)
     }
 
     messageCache.shift()
     for (let i = 40; i < 50; i++) {
-      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i], true)
     }
 
     messageCache.shift()
     for (let i = 50; i < 60; i++) {
-      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i])
+      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i], true)
     }
 
     expect(messageCache.msgs.size).to.equal(50)
@@ -132,6 +132,28 @@ describe('Testing Message Cache Operations', () => {
     for (let i = 20; i < 30; i++) {
       const messageID = getMsgId(testMessages[10 + i])
       expect(messageID).to.deep.equal(gossipIDs[i])
+    }
+  })
+
+  it('should not gossip not-validated message ids', () => {
+    let gossipIDs = messageCache.getGossipIDs('test')
+    while (gossipIDs.length > 0) {
+      messageCache.shift()
+      gossipIDs = messageCache.getGossipIDs('test')
+    }
+    expect(gossipIDs.length).to.be.equal(0)
+
+    for (let i = 10; i < 20; i++) {
+      // 5 last messages are not validated
+      const validated = i < 15
+      messageCache.put(messageIdToString(getMsgId(testMessages[i])), testMessages[i], validated)
+    }
+
+    gossipIDs = messageCache.getGossipIDs('test')
+    expect(gossipIDs.length).to.be.equal(5)
+    // only validate the new gossip ids
+    for (let i = 0; i < 5; i++) {
+      expect(gossipIDs[i]).to.deep.equal(getMsgId(testMessages[i + 10]), 'incorrect gossip message id ' + i)
     }
   })
 })

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -867,7 +867,8 @@ export default class Gossipsub extends EventEmitter {
         this.gossipTracer.deliverMessage(msgIdStr)
 
         // Add the message to our memcache
-        this.mcache.put(msgIdStr, rpcMsg)
+        // if no validation is required, mark the message as validated
+        this.mcache.put(msgIdStr, rpcMsg, !this.opts.asyncValidation)
 
         // Dispatch the message to the user if we are subscribed to the topic
         if (this.subscriptions.has(rpcMsg.topic)) {
@@ -1818,7 +1819,8 @@ export default class Gossipsub extends EventEmitter {
     // If the message isn't a duplicate and we have sent it to some peers add it to the
     // duplicate cache and memcache.
     this.seenCache.put(msgIdStr)
-    this.mcache.put(msgIdStr, rawMsg)
+    // all published messages are valid
+    this.mcache.put(msgIdStr, rawMsg, true)
 
     // If the message is anonymous or has a random author add it to the published message ids cache.
     this.publishedMessageIds.put(msgIdStr)

--- a/ts/message-cache.ts
+++ b/ts/message-cache.ts
@@ -53,7 +53,7 @@ export class MessageCache {
    * Adds a message to the current window and the cache
    * Returns true if the message is not known and is inserted in the cache
    */
-  put(msgIdStr: MsgIdStr, msg: RPC.IMessage): boolean {
+  put(msgIdStr: MsgIdStr, msg: RPC.IMessage, validated = false): boolean {
     // Don't add duplicate entries to the cache.
     if (this.msgs.has(msgIdStr)) {
       return false
@@ -61,7 +61,7 @@ export class MessageCache {
 
     this.msgs.set(msgIdStr, {
       message: msg,
-      validated: false,
+      validated,
       originatingPeers: new Set(),
       iwantCounts: new Map()
     })
@@ -115,8 +115,9 @@ export class MessageCache {
     const msgIds: Uint8Array[] = []
     for (let i = 0; i < this.gossip; i++) {
       this.history[i].forEach((entry) => {
-        if (entry.topic === topic) {
-          msgIds.push(entry.msgId)
+        const { msgId } = entry
+        if (entry.topic === topic && this.msgs.get(messageIdToString(msgId))?.validated) {
+          msgIds.push(msgId)
         }
       })
     }


### PR DESCRIPTION
**Motivation**

- See https://github.com/ChainSafe/lodestar/issues/4412#issuecomment-1214947600
- Similar fix to #277 but we want to make a hot fix to 0.14.x

**Description**
- only gossip validated messages
- for applications that don't use `asyncValidation`, the message is validated once it put in the cache