### PR TITLE
fix: skip heartbeat only if it's close to the next heartbeat

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@typescript-eslint/parser": "^3.0.2",
     "aegir": "^37.2.0",
     "benchmark": "^2.1.4",
-    "datastore-core": "^7.0.1",
+    "datastore-core": "^8.0.1",
     "delay": "^5.0.0",
     "detect-node": "^2.1.0",
     "eslint": "^7.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2327,7 +2327,8 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
 
           // NodeJS setInterval function is innexact, calls drift by a few miliseconds on each call.
           // To run the heartbeat precisely setTimeout() must be used recomputing the delay on every loop.
-          let msToNextHeartbeat = (Date.now() - this.status.hearbeatStartMs) % this.opts.heartbeatInterval
+          let msToNextHeartbeat =
+            this.opts.heartbeatInterval - ((Date.now() - this.status.hearbeatStartMs) % this.opts.heartbeatInterval)
 
           // If too close to next heartbeat, skip one
           if (msToNextHeartbeat < this.opts.heartbeatInterval * 0.25) {


### PR DESCRIPTION
**Motivation**
See #331 

**Description**
- Fix the condition to skip the heartbeat, right now it looks like we skip if heartbeat runs too fast
- The result is like
<img width="812" alt="Screen Shot 2022-08-24 at 15 50 12" src="https://user-images.githubusercontent.com/10568965/186374436-94824b65-9cd4-492f-8315-17d55a1c08bf.png">

Closes #331 
