### PR TITLE
fix: update event type to extend `{ [s: string]: any }`

### DIFF
--- a/test/utils/events.ts
+++ b/test/utils/events.ts
@@ -60,7 +60,7 @@ export const checkReceivedSubscriptions = async (
   })
 }
 
-export const awaitEvents = async <Events = GossipsubEvents>(
+export const awaitEvents = async <Events extends { [s: string]: any } = GossipsubEvents>(
   emitter: EventEmitter<Events>,
   event: keyof Events,
   number: number,


### PR DESCRIPTION
The `Events` type has to extend `{ [s: string]: any }`. Hopefully one day TS will ship a typed `EventEmitter` and this won't be necessary any more.

Fixes a type error:

```
[10:45:49] tsc [started]
test/utils/events.ts:64:25 - error TS2344: Type 'Events' does not satisfy the constraint '{ [s: string]: any; }'.

64   emitter: EventEmitter<Events>,
                           ~~~~~~

  test/utils/events.ts:63:35
    63 export const awaitEvents = async <Events = GossipsubEvents>(
                                         ~~~~~~~~~~~~~~~~~~~~~~~~
    This type parameter might need an `extends { [s: string]: any; }` constraint.


Found 1 error in test/utils/events.ts:64
```