### PR TITLE
feat: add `src` folder to package to enable access to source map

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A typescript implementation of gossipsub",
   "leadMaintainer": "Cayman Nava <caymannava@gmail.com>",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "type": "module",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Useful when the project use tooling to access the source map.