### PR TITLE
fix: update @multiformats/multiaddr to 11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@libp2p/interface-pubsub-compliance-tests": "^2.0.2",
     "@libp2p/peer-id-factory": "^1.0.18",
     "@libp2p/peer-store": "^3.1.2",
-    "@multiformats/multiaddr": "^10.3.3",
+    "@multiformats/multiaddr": "^11.0.0",
     "@types/node": "^17.0.21",
     "@typescript-eslint/eslint-plugin": "^3.0.2",
     "@typescript-eslint/parser": "^3.0.2",


### PR DESCRIPTION
As far as I can see this is only used in an interface so the only change needed is to the `package.json` file.