### PR TITLE
fix: copy js files to dist manually

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "lint": "eslint --ext .ts src test",
     "release": "aegir release --no-types",
-    "build": "aegir build && cp src/message/rpc.d.ts dist/src/message",
+    "build": "mkdir -p dist/src/message && cp src/message/*.* dist/src/message && aegir build",
     "prepare": "npm run build",
     "pretest": "npm run build",
     "pretest:e2e": "npm run build",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "scripts": {
     "lint": "eslint --ext .ts src test",
     "release": "aegir release --no-types",
-    "build": "mkdir -p dist/src/message && cp src/message/*.* dist/src/message && aegir build",
+    "copy": "mkdirp dist/src/message && cp src/message/*.* dist/src/message",
+    "build": "npm run copy && aegir build",
     "prepare": "npm run build",
     "pretest": "npm run build",
     "pretest:e2e": "npm run build",
@@ -126,6 +127,7 @@
     "time-cache": "^0.3.0",
     "ts-node": "^10.7.0",
     "ts-sinon": "^2.0.2",
+    "mkdirp": "^1.0.4",
     "util": "^0.12.3"
   },
   "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "noImplicitReturns": true,
     "outDir": "dist",
     "useUnknownInCatchVariables": true,
+    "allowJs": false,
     "checkJs": false
   },
   "include": [


### PR DESCRIPTION
**Description**
- There is build issue
```
Error: R] No matching export in "dist/src/message/rpc.cjs" for import "default"

    dist/src/message/rpc.js:1:7:
      1 │ import cjs from "./rpc.cjs";
```
- root cause is
```
This file is considered to be an ECMAScript module because of the "export" keyword here:

    dist/src/message/rpc.cjs:1747:0:
      1747 │ export {};
```

**Description**
During build process, js files are automatically copied to `dist` folder and some how it added 1 extra line at the end
```
export {};
```
and it made `rpc.cjs` file an esm module

- The fix is to copy js files automatically
