### PR TITLE
feat: Add stream option to limit inbound message size

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,13 @@ export interface GossipsubOpts extends GossipsubOptsSpec, PubSubInit {
   maxOutboundBufferSize?: number
 
   /**
+   * Specify max size to skip decoding messages whose data
+   * section exceeds this size.
+   *
+   */
+  maxInboundDataLength?: number
+
+  /**
    * If provided, only allow topics in this list
    */
   allowedTopics?: string[] | Set<string>
@@ -772,7 +779,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
 
     this.log('create inbound stream %s', id)
 
-    const inboundStream = new InboundStream(stream)
+    const inboundStream = new InboundStream(stream, { maxDataLength: this.opts.maxInboundDataLength })
     this.streamsInbound.set(id, inboundStream)
 
     this.pipePeerReadStream(peerId, inboundStream.source).catch((err) => this.log(err))

--- a/src/index.ts
+++ b/src/index.ts
@@ -930,9 +930,17 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
         }
       })
     } catch (err) {
-      this.log.error(err)
-      this.onPeerDisconnected(peerId)
+      this.handlePeerReadStreamError(err as Error, peerId)
     }
+  }
+
+  /**
+   * Handle error when read stream pipe throws, less of the functional use but more
+   * to for testing purposes to spy on the error handling
+   * */
+  private handlePeerReadStreamError(err: Error, peerId: PeerId): void {
+    this.log.error(err)
+    this.onPeerDisconnected(peerId)
   }
 
   /**

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -10,6 +10,11 @@ type OutboundStreamOpts = {
   maxBufferSize?: number
 }
 
+type InboundStreamOpts = {
+  /** Max size in bytes for reading messages from the stream */
+  maxDataLength?: number
+}
+
 export class OutboundStream {
   private readonly pushable: Pushable<Uint8Array>
   private readonly closeController: AbortController
@@ -54,11 +59,11 @@ export class InboundStream {
   private readonly rawStream: Stream
   private readonly closeController: AbortController
 
-  constructor(rawStream: Stream) {
+  constructor(rawStream: Stream, opts: InboundStreamOpts) {
     this.rawStream = rawStream
     this.closeController = new AbortController()
 
-    this.source = abortableSource(pipe(this.rawStream, decode()), this.closeController.signal, { returnOnAbort: true })
+    this.source = abortableSource(pipe(this.rawStream, decode(opts)), this.closeController.signal, { returnOnAbort: true })
   }
 
   close(): void {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -59,11 +59,13 @@ export class InboundStream {
   private readonly rawStream: Stream
   private readonly closeController: AbortController
 
-  constructor(rawStream: Stream, opts: InboundStreamOpts) {
+  constructor(rawStream: Stream, opts: InboundStreamOpts = {}) {
     this.rawStream = rawStream
     this.closeController = new AbortController()
 
-    this.source = abortableSource(pipe(this.rawStream, decode(opts)), this.closeController.signal, { returnOnAbort: true })
+    this.source = abortableSource(pipe(this.rawStream, decode(opts)), this.closeController.signal, {
+      returnOnAbort: true
+    })
   }
 
   close(): void {


### PR DESCRIPTION
If the size is not provided `decode` from `it-length-prefixed` lib applies the ~4mb limit by default:
From npm docs: 
```
maxDataLength: If provided, will not decode messages whose data section exceeds the size specified, if omitted will use the default of 4MB.
```

bellatrix message sizes could be 10MB so this limit needs to be exposed via options so they can be set by lodestar