### PR TITLE
feat: allow to customize decode RPC function

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -111,7 +111,9 @@ export enum ScorePenalty {
   /// A Peer did not send enough messages as expected.
   MessageDeficit = 'message_deficit',
   /// Too many peers under one IP address.
-  IPColocation = 'IP_colocation'
+  IPColocation = 'IP_colocation',
+  /** Invalid RPC message */
+  InvalidRPC = 'invalid_rpc'
 }
 
 export enum IHaveIgnoreReason {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { PrivateKey } from '@libp2p/interface-keys'
 import type { Multiaddr } from '@multiformats/multiaddr'
-import type { RPC } from './message/rpc.js'
+import { IRPC, RPC } from './message/rpc.js'
 import type { Message } from '@libp2p/interface-pubsub'
 
 export type MsgIdStr = string
@@ -167,6 +167,8 @@ export type MessageId = {
   msgId: Uint8Array
   msgIdStr: MsgIdStr
 }
+
+export type DecodeRpcFn = (rpcBytes: Uint8Array) => IRPC
 
 /**
  * Typesafe conversion of MessageAcceptance -> RejectReason. TS ensures all values covered


### PR DESCRIPTION
Lodestar has some specific security needs and would require a hardened version of RPC.decode. Customizing this function allows Lodestar to experiment without requiring constant upstream changes