### PR TITLE
feat: limit RPC lists on decode

### DIFF
--- a/src/message/decodeRpc.ts
+++ b/src/message/decodeRpc.ts
@@ -1,0 +1,239 @@
+import { IRPC, RPC } from './rpc'
+import protobuf from 'protobufjs/minimal.js'
+
+export type DecodeRPCLimits = {
+  maxSubscriptions: number
+  maxMessages: number
+  maxMessageIDs: number
+  maxControlMessages: number
+}
+
+export const defaultDecodeRpcLimits: DecodeRPCLimits = {
+  maxSubscriptions: Infinity,
+  maxMessages: Infinity,
+  maxMessageIDs: Infinity,
+  maxControlMessages: Infinity
+}
+
+/**
+ * Copied code from src/message/rpc.cjs but with decode limits to prevent OOM attacks
+ */
+export function decodeRpc(bytes: Uint8Array, opts: DecodeRPCLimits): IRPC {
+  const r = protobuf.Reader.create(bytes)
+  const l = bytes.length
+
+  const c = l === undefined ? r.len : r.pos + l
+  const m: IRPC = {}
+  while (r.pos < c) {
+    const t = r.uint32()
+    switch (t >>> 3) {
+      case 1:
+        if (!(m.subscriptions && m.subscriptions.length)) m.subscriptions = []
+        if (m.subscriptions.length < opts.maxSubscriptions) m.subscriptions.push(decodeSubOpts(r, r.uint32()))
+        else r.skipType(t & 7)
+        break
+      case 2:
+        if (!(m.messages && m.messages.length)) m.messages = []
+        if (m.messages.length < opts.maxMessages) m.messages.push(decodeMessage(r, r.uint32()))
+        else r.skipType(t & 7)
+        break
+      case 3:
+        m.control = decodeControlMessage(r, r.uint32(), opts)
+        break
+      default:
+        r.skipType(t & 7)
+        break
+    }
+  }
+  return m
+}
+
+function decodeSubOpts(r: protobuf.Reader, l: number) {
+  const c = l === undefined ? r.len : r.pos + l
+  const m: RPC.ISubOpts = {}
+  while (r.pos < c) {
+    const t = r.uint32()
+    switch (t >>> 3) {
+      case 1:
+        m.subscribe = r.bool()
+        break
+      case 2:
+        m.topic = r.string()
+        break
+      default:
+        r.skipType(t & 7)
+        break
+    }
+  }
+  return m
+}
+
+function decodeMessage(r: protobuf.Reader, l: number) {
+  const c = l === undefined ? r.len : r.pos + l
+  const m = {} as RPC.IMessage
+  while (r.pos < c) {
+    const t = r.uint32()
+    switch (t >>> 3) {
+      case 1:
+        m.from = r.bytes()
+        break
+      case 2:
+        m.data = r.bytes()
+        break
+      case 3:
+        m.seqno = r.bytes()
+        break
+      case 4:
+        m.topic = r.string()
+        break
+      case 5:
+        m.signature = r.bytes()
+        break
+      case 6:
+        m.key = r.bytes()
+        break
+      default:
+        r.skipType(t & 7)
+        break
+    }
+  }
+  if (!m.topic) throw Error("missing required 'topic'")
+  return m
+}
+
+function decodeControlMessage(r: protobuf.Reader, l: number, opts: DecodeRPCLimits) {
+  const c = l === undefined ? r.len : r.pos + l
+  const m = {} as RPC.IControlMessage
+  while (r.pos < c) {
+    const t = r.uint32()
+    switch (t >>> 3) {
+      case 1:
+        if (!(m.ihave && m.ihave.length)) m.ihave = []
+        if (m.ihave.length < opts.maxControlMessages) m.ihave.push(decodeControlIHave(r, r.uint32(), opts))
+        else r.skipType(t & 7)
+        break
+      case 2:
+        if (!(m.iwant && m.iwant.length)) m.iwant = []
+        if (m.iwant.length < opts.maxControlMessages) m.iwant.push(decodeControlIWant(r, r.uint32(), opts))
+        else r.skipType(t & 7)
+        break
+      case 3:
+        if (!(m.graft && m.graft.length)) m.graft = []
+        if (m.graft.length < opts.maxControlMessages) m.graft.push(decodeControlGraft(r, r.uint32()))
+        else r.skipType(t & 7)
+        break
+      case 4:
+        if (!(m.prune && m.prune.length)) m.prune = []
+        if (m.prune.length < opts.maxControlMessages) m.prune.push(decodeControlPrune(r, r.uint32(), opts))
+        else r.skipType(t & 7)
+        break
+      default:
+        r.skipType(t & 7)
+        break
+    }
+  }
+  return m
+}
+
+function decodeControlIHave(r: protobuf.Reader, l: number, opts: DecodeRPCLimits) {
+  const c = l === undefined ? r.len : r.pos + l
+  const m = {} as RPC.IControlIHave
+  while (r.pos < c) {
+    const t = r.uint32()
+    switch (t >>> 3) {
+      case 1:
+        m.topicID = r.string()
+        break
+      case 2:
+        if (!(m.messageIDs && m.messageIDs.length)) m.messageIDs = []
+        if (m.messageIDs.length < opts.maxMessageIDs) m.messageIDs.push(r.bytes())
+        else r.skipType(t & 7)
+        break
+      default:
+        r.skipType(t & 7)
+        break
+    }
+  }
+  return m
+}
+
+function decodeControlIWant(r: protobuf.Reader, l: number, opts: DecodeRPCLimits) {
+  const c = l === undefined ? r.len : r.pos + l
+  const m = {} as RPC.IControlIWant
+  while (r.pos < c) {
+    const t = r.uint32()
+    switch (t >>> 3) {
+      case 1:
+        if (!(m.messageIDs && m.messageIDs.length)) m.messageIDs = []
+        if (m.messageIDs.length < opts.maxMessageIDs) m.messageIDs.push(r.bytes())
+        else r.skipType(t & 7)
+        break
+      default:
+        r.skipType(t & 7)
+        break
+    }
+  }
+  return m
+}
+
+function decodeControlGraft(r: protobuf.Reader, l: number) {
+  const c = l === undefined ? r.len : r.pos + l
+  const m = {} as RPC.IControlGraft
+  while (r.pos < c) {
+    const t = r.uint32()
+    switch (t >>> 3) {
+      case 1:
+        m.topicID = r.string()
+        break
+      default:
+        r.skipType(t & 7)
+        break
+    }
+  }
+  return m
+}
+
+function decodeControlPrune(r: protobuf.Reader, l: number, opts: DecodeRPCLimits) {
+  const c = l === undefined ? r.len : r.pos + l
+  const m = {} as RPC.IControlPrune
+  while (r.pos < c) {
+    const t = r.uint32()
+    switch (t >>> 3) {
+      case 1:
+        m.topicID = r.string()
+        break
+      case 2:
+        if (!(m.peers && m.peers.length)) m.peers = []
+        if (m.peers.length < opts.maxMessages) m.peers.push(decodePeerInfo(r, r.uint32()))
+        else r.skipType(t & 7)
+        break
+      case 3:
+        m.backoff = r.uint64() as unknown as number
+        break
+      default:
+        r.skipType(t & 7)
+        break
+    }
+  }
+  return m
+}
+
+function decodePeerInfo(r: protobuf.Reader, l: number) {
+  const c = l === undefined ? r.len : r.pos + l
+  const m = {} as RPC.IPeerInfo
+  while (r.pos < c) {
+    const t = r.uint32()
+    switch (t >>> 3) {
+      case 1:
+        m.peerID = r.bytes()
+        break
+      case 2:
+        m.signedPeerRecord = r.bytes()
+        break
+      default:
+        r.skipType(t & 7)
+        break
+    }
+  }
+  return m
+}

--- a/src/message/decodeRpc.ts
+++ b/src/message/decodeRpc.ts
@@ -154,7 +154,7 @@ function decodeControlIHave(r: protobuf.Reader, l: number, opts: DecodeRPCLimits
         break
       case 2:
         if (!(m.messageIDs && m.messageIDs.length)) m.messageIDs = []
-        if (m.messageIDs.length < opts.maxIhaveMessageIDs--) m.messageIDs.push(r.bytes())
+        if (opts.maxIhaveMessageIDs-- > 0) m.messageIDs.push(r.bytes())
         else r.skipType(t & 7)
         break
       default:
@@ -173,7 +173,7 @@ function decodeControlIWant(r: protobuf.Reader, l: number, opts: DecodeRPCLimits
     switch (t >>> 3) {
       case 1:
         if (!(m.messageIDs && m.messageIDs.length)) m.messageIDs = []
-        if (m.messageIDs.length < opts.maxIwantMessageIDs--) m.messageIDs.push(r.bytes())
+        if (opts.maxIwantMessageIDs-- > 0) m.messageIDs.push(r.bytes())
         else r.skipType(t & 7)
         break
       default:
@@ -212,7 +212,7 @@ function decodeControlPrune(r: protobuf.Reader, l: number, opts: DecodeRPCLimits
         break
       case 2:
         if (!(m.peers && m.peers.length)) m.peers = []
-        if (m.peers.length < opts.maxPeerInfos--) m.peers.push(decodePeerInfo(r, r.uint32()))
+        if (opts.maxPeerInfos-- > 0) m.peers.push(decodePeerInfo(r, r.uint32()))
         else r.skipType(t & 7)
         break
       case 3:

--- a/test/decodeRpc.spec.ts
+++ b/test/decodeRpc.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai'
+import { expect } from 'aegir/chai'
 import { decodeRpc, DecodeRPCLimits, defaultDecodeRpcLimits } from '../src/message/decodeRpc.js'
 import { RPC, IRPC } from '../src/message/index.js'
 

--- a/test/decodeRpc.spec.ts
+++ b/test/decodeRpc.spec.ts
@@ -39,10 +39,17 @@ describe('decodeRpc', () => {
       maxSubscriptions: 2,
       maxMessages: 2,
       maxControlMessages: 2,
-      maxIhaveMessageIDs: 2,
-      maxIwantMessageIDs: 2,
-      maxPeerInfos: 2
+      maxIhaveMessageIDs: 3,
+      maxIwantMessageIDs: 3,
+      maxPeerInfos: 3
     }
+
+    // Check no mutations on limits
+    const limitsAfter = { ...decodeRpcLimits }
+
+    after('decodeRpcLimits has not been mutated', () => {
+      expect(limitsAfter).deep.equals(decodeRpcLimits)
+    })
 
     const rpcEmpty: IRPC = {
       subscriptions: [],
@@ -57,59 +64,68 @@ describe('decodeRpc', () => {
 
     const rpcEmptyBytes = RPC.encode(rpcEmpty).finish()
 
-    it('max subscriptions', () => {
+    it('limit subscriptions.length', () => {
       // Decode a fresh instance to allow safe mutations
       const rpc = RPC.decode(rpcEmptyBytes)
       rpc.subscriptions = [subscription, subscription, subscription]
-      expect(endecode(rpc).subscriptions).length(2, 'wrong subscriptions.length after decode')
+      expect(endecode(rpc).subscriptions).length(decodeRpcLimits.maxSubscriptions)
     })
 
-    it('max messages', () => {
+    it('limit messages.length', () => {
       const rpc = RPC.decode(rpcEmptyBytes)
       rpc.messages = [message, message, message]
-      expect(endecode(rpc).messages).length(2, 'wrong messages.length after decode')
+      expect(endecode(rpc).messages).length(decodeRpcLimits.maxMessages)
     })
 
-    it('max ihave', () => {
+    it('limit control.ihave.length', () => {
       const rpc = RPC.decode(rpcEmptyBytes)
       rpc.control = { ihave: [ihave, ihave, ihave] }
-      expect(endecode(rpc).control?.ihave).length(2, 'wrong control.ihave.length after decode')
+      expect(endecode(rpc).control?.ihave).length(decodeRpcLimits.maxControlMessages)
     })
 
-    it('max iwant', () => {
+    it('limit control.iwant.length', () => {
       const rpc = RPC.decode(rpcEmptyBytes)
       rpc.control = { iwant: [iwant, iwant, iwant] }
-      expect(endecode(rpc).control?.iwant).length(2, 'wrong control.iwant.length after decode')
+      expect(endecode(rpc).control?.iwant).length(decodeRpcLimits.maxControlMessages)
     })
 
-    it('max graft', () => {
+    it('limit control.graft.length', () => {
       const rpc = RPC.decode(rpcEmptyBytes)
       rpc.control = { graft: [graft, graft, graft] }
-      expect(endecode(rpc).control?.graft).length(2, 'wrong control.graft.length after decode')
+      expect(endecode(rpc).control?.graft).length(decodeRpcLimits.maxControlMessages)
     })
 
-    it('max prune', () => {
+    it('limit control.prune.length', () => {
       const rpc = RPC.decode(rpcEmptyBytes)
       rpc.control = { prune: [prune, prune, prune] }
-      expect(endecode(rpc).control?.prune).length(2, 'wrong control.prune.length after decode')
+      expect(endecode(rpc).control?.prune).length(decodeRpcLimits.maxControlMessages)
     })
 
-    it('max ihave.messageIDs', () => {
+    it('limit ihave.messageIDs.length', () => {
       const rpc = RPC.decode(rpcEmptyBytes)
-      rpc.control = { ihave: [{ messageIDs: [msgID, msgID, msgID] }] }
-      expect(endecode(rpc).control?.ihave?.[0].messageIDs).length(2, 'wrong ihave.[0].messageIDs.length after decode')
+      // Limit to 3 items total, 2 (all) on the first one, 1 on the second one
+      rpc.control = { ihave: [{ messageIDs: [msgID, msgID] }, { messageIDs: [msgID, msgID] }] }
+      expect(decodeRpcLimits.maxIhaveMessageIDs).equals(3, 'Wrong maxIhaveMessageIDs')
+      expect(endecode(rpc).control?.ihave?.[0].messageIDs).length(2, 'Wrong ihave?.[0].messageIDs len')
+      expect(endecode(rpc).control?.ihave?.[1].messageIDs).length(1, 'Wrong ihave?.[1].messageIDs len')
     })
 
-    it('max iwant.messageIDs', () => {
+    it('limit iwant.messageIDs.length', () => {
       const rpc = RPC.decode(rpcEmptyBytes)
-      rpc.control = { iwant: [{ messageIDs: [msgID, msgID, msgID] }] }
-      expect(endecode(rpc).control?.iwant?.[0].messageIDs).length(2, 'wrong iwant.[0].messageIDs.length after decode')
+      // Limit to 3 items total, 2 (all) on the first one, 1 on the second one
+      rpc.control = { iwant: [{ messageIDs: [msgID, msgID] }, { messageIDs: [msgID, msgID] }] }
+      expect(decodeRpcLimits.maxIwantMessageIDs).equals(3, 'Wrong maxIwantMessageIDs')
+      expect(endecode(rpc).control?.iwant?.[0].messageIDs).length(2, 'Wrong iwant?.[0].messageIDs len')
+      expect(endecode(rpc).control?.iwant?.[1].messageIDs).length(1, 'Wrong iwant?.[1].messageIDs len')
     })
 
-    it('max prune.peers', () => {
+    it('limit prune.peers.length', () => {
       const rpc = RPC.decode(rpcEmptyBytes)
-      rpc.control = { prune: [{ peers: [peerInfo, peerInfo, peerInfo] }] }
-      expect(endecode(rpc).control?.prune?.[0].peers).length(2, 'wrong peers.[0].peers.length after decode')
+      // Limit to 3 items total, 2 (all) on the first one, 1 on the second one
+      rpc.control = { prune: [{ peers: [peerInfo, peerInfo] }, { peers: [peerInfo, peerInfo] }] }
+      expect(decodeRpcLimits.maxPeerInfos).equals(3, 'Wrong maxPeerInfos')
+      expect(endecode(rpc).control?.prune?.[0].peers).length(2, 'Wrong prune?.[0].peers len')
+      expect(endecode(rpc).control?.prune?.[1].peers).length(1, 'Wrong prune?.[1].peers len')
     })
 
     function endecode(rpc: IRPC): IRPC {

--- a/test/decodeRpc.spec.ts
+++ b/test/decodeRpc.spec.ts
@@ -1,0 +1,117 @@
+import { expect } from 'chai'
+import { decodeRpc, DecodeRPCLimits, defaultDecodeRpcLimits } from '../src/message/decodeRpc.js'
+import { RPC, IRPC } from '../src/message/index.js'
+
+describe('decodeRpc', () => {
+  const topicID = 'topic'
+  const msgID = new Uint8Array(8)
+
+  const subscription: RPC.ISubOpts = { subscribe: true, topic: topicID }
+  const message: RPC.IMessage = { topic: topicID, data: new Uint8Array(100) }
+  const peerInfo: RPC.IPeerInfo = { peerID: msgID, signedPeerRecord: msgID }
+  const ihave: RPC.IControlIHave = { topicID, messageIDs: [msgID] }
+  const iwant: RPC.IControlIWant = { messageIDs: [msgID] }
+  const graft: RPC.IControlGraft = { topicID }
+  const prune: RPC.IControlPrune = { topicID, peers: [peerInfo] }
+
+  describe('decode correctness', () => {
+    it('Should decode full RPC', () => {
+      const rpc: IRPC = {
+        subscriptions: [subscription, subscription],
+        messages: [message, message],
+        control: {
+          ihave: [ihave, ihave],
+          iwant: [iwant, iwant],
+          graft: [graft, graft],
+          prune: [prune, prune]
+        }
+      }
+
+      const bytes = RPC.encode(rpc).finish()
+
+      // Compare as JSON
+      expect(RPC.fromObject(decodeRpc(bytes, defaultDecodeRpcLimits)).toJSON()).deep.equals(RPC.decode(bytes).toJSON())
+    })
+  })
+
+  describe('decode limits', () => {
+    const decodeRpcLimits: DecodeRPCLimits = {
+      maxSubscriptions: 2,
+      maxMessages: 2,
+      maxMessageIDs: 2,
+      maxControlMessages: 2
+    }
+
+    const rpcEmpty: IRPC = {
+      subscriptions: [],
+      messages: [],
+      control: {
+        ihave: [],
+        iwant: [],
+        graft: [],
+        prune: []
+      }
+    }
+
+    const rpcEmptyBytes = RPC.encode(rpcEmpty).finish()
+
+    it('max subscriptions', () => {
+      // Decode a fresh instance to allow safe mutations
+      const rpc = RPC.decode(rpcEmptyBytes)
+      rpc.subscriptions = [subscription, subscription, subscription]
+      expect(endecode(rpc).subscriptions).length(2, 'wrong subscriptions.length after decode')
+    })
+
+    it('max messages', () => {
+      const rpc = RPC.decode(rpcEmptyBytes)
+      rpc.messages = [message, message, message]
+      expect(endecode(rpc).messages).length(2, 'wrong messages.length after decode')
+    })
+
+    it('max ihave', () => {
+      const rpc = RPC.decode(rpcEmptyBytes)
+      rpc.control = { ihave: [ihave, ihave, ihave] }
+      expect(endecode(rpc).control?.ihave).length(2, 'wrong control.ihave.length after decode')
+    })
+
+    it('max iwant', () => {
+      const rpc = RPC.decode(rpcEmptyBytes)
+      rpc.control = { iwant: [iwant, iwant, iwant] }
+      expect(endecode(rpc).control?.iwant).length(2, 'wrong control.iwant.length after decode')
+    })
+
+    it('max graft', () => {
+      const rpc = RPC.decode(rpcEmptyBytes)
+      rpc.control = { graft: [graft, graft, graft] }
+      expect(endecode(rpc).control?.graft).length(2, 'wrong control.graft.length after decode')
+    })
+
+    it('max prune', () => {
+      const rpc = RPC.decode(rpcEmptyBytes)
+      rpc.control = { prune: [prune, prune, prune] }
+      expect(endecode(rpc).control?.prune).length(2, 'wrong control.prune.length after decode')
+    })
+
+    it('max ihave.messageIDs', () => {
+      const rpc = RPC.decode(rpcEmptyBytes)
+      rpc.control = { ihave: [{ messageIDs: [msgID, msgID, msgID] }] }
+      expect(endecode(rpc).control?.ihave?.[0].messageIDs).length(2, 'wrong ihave.[0].messageIDs.length after decode')
+    })
+
+    it('max iwant.messageIDs', () => {
+      const rpc = RPC.decode(rpcEmptyBytes)
+      rpc.control = { iwant: [{ messageIDs: [msgID, msgID, msgID] }] }
+      expect(endecode(rpc).control?.iwant?.[0].messageIDs).length(2, 'wrong iwant.[0].messageIDs.length after decode')
+    })
+
+    it('max prune.peers', () => {
+      const rpc = RPC.decode(rpcEmptyBytes)
+      rpc.control = { prune: [{ peers: [peerInfo, peerInfo, peerInfo] }] }
+      expect(endecode(rpc).control?.prune?.[0].peers).length(2, 'wrong peers.[0].peers.length after decode')
+    })
+
+    function endecode(rpc: IRPC): IRPC {
+      return decodeRpc(RPC.encode(rpc).finish(), decodeRpcLimits)
+    }
+  })
+})

--- a/test/decodeRpc.spec.ts
+++ b/test/decodeRpc.spec.ts
@@ -38,8 +38,10 @@ describe('decodeRpc', () => {
     const decodeRpcLimits: DecodeRPCLimits = {
       maxSubscriptions: 2,
       maxMessages: 2,
-      maxMessageIDs: 2,
-      maxControlMessages: 2
+      maxControlMessages: 2,
+      maxIhaveMessageIDs: 2,
+      maxIwantMessageIDs: 2,
+      maxPeerInfos: 2
     }
 
     const rpcEmpty: IRPC = {


### PR DESCRIPTION
protobuf allows for unlimited list length. Applications can indirectly limit the max length by limiting the max size of incoming RPC packets. However, lists can be filled with tinny elements of 1 byte each that expand to much more. A well crafted RPC can expand x80 or more it's encoded size. By limiting RPC protobuf list length, the multiplier factor is greatly reduced. This approach is adopted by libp2p java and libp2p rust.

The code from `src/message/decodeRpc.ts` is copied from `src/message/rpc.cjs`. Ideally we want to upstream this capability, but this PR should be merged before