### PR TITLE
fix: flip conditional in piggyback control - typo from #347

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2158,7 +2158,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
       if (!outRpc.control) outRpc.control = {}
       if (!outRpc.control.prune) outRpc.control.prune = []
       for (const prune of ctrl.prune) {
-        if (prune.topicID && this.mesh.get(prune.topicID)?.has(id)) {
+        if (prune.topicID && !this.mesh.get(prune.topicID)?.has(id)) {
           outRpc.control.prune.push(prune)
         }
       }


### PR DESCRIPTION
- Fixes typo from https://github.com/ChainSafe/js-libp2p-gossipsub/pull/347 with did not include a negation in a conditional check

@wemeetagain and I believe this logic appears strange and may be flipped. Asked in relevant channels https://discord.com/channels/806902334369824788/942671304530747402/1026542001082077184
