### PR TITLE
feat: support FastMsgIdFn returning a number

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1085,7 +1085,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
   ): Promise<ReceivedMessageResult> {
     // Fast message ID stuff
     const fastMsgIdStr = this.fastMsgIdFn?.(rpcMsg)
-    const msgIdCached = fastMsgIdStr ? this.fastMsgIdCache?.get(fastMsgIdStr) : undefined
+    const msgIdCached = fastMsgIdStr !== undefined ? this.fastMsgIdCache?.get(fastMsgIdStr) : undefined
 
     if (msgIdCached) {
       // This message has been seen previously. Ignore it
@@ -1122,7 +1122,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     const messageId = { msgId, msgIdStr }
 
     // Add the message to the duplicate caches
-    if (fastMsgIdStr) this.fastMsgIdCache?.put(fastMsgIdStr, msgIdStr)
+    if (fastMsgIdStr !== undefined) this.fastMsgIdCache?.put(fastMsgIdStr, msgIdStr)
 
     if (this.seenCache.has(msgIdStr)) {
       return { code: MessageStatus.duplicate, msgIdStr }

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export interface AddrInfo {
  * Compute a local non-spec'ed msg-id for faster de-duplication of seen messages.
  * Used exclusively for a local seen_cache
  */
-export type FastMsgIdFn = (msg: RPC.IMessage) => string
+export type FastMsgIdFn = (msg: RPC.IMessage) => string | number
 
 /**
  * By default, gossipsub only provide a browser friendly function to convert Uint8Array message id to string.

--- a/src/utils/time-cache.ts
+++ b/src/utils/time-cache.ts
@@ -13,7 +13,7 @@ type CacheValue<T> = {
  * This gives 4x - 5x performance gain compared to npm TimeCache
  */
 export class SimpleTimeCache<T> {
-  private readonly entries = new Map<string, CacheValue<T>>()
+  private readonly entries = new Map<string | number, CacheValue<T>>()
   private readonly validityMs: number
 
   constructor(opts: SimpleTimeCacheOpts) {
@@ -27,7 +27,7 @@ export class SimpleTimeCache<T> {
     return this.entries.size
   }
 
-  put(key: string, value: T): void {
+  put(key: string | number, value: T): void {
     this.entries.set(key, { value, validUntilMs: Date.now() + this.validityMs })
   }
 
@@ -48,7 +48,7 @@ export class SimpleTimeCache<T> {
     return this.entries.has(key)
   }
 
-  get(key: string): T | undefined {
+  get(key: string | number): T | undefined {
     const value = this.entries.get(key)
     return value && value.validUntilMs >= Date.now() ? value.value : undefined
   }


### PR DESCRIPTION
**Motivation**
- lodestar wants to configure a `fastMsgIdFn` returning a number, see https://github.com/ChainSafe/lodestar/pull/4630/files#diff-9bf17f9668e6c2f27a8beb7f42a7c1a39554a322be5c7843b1def7670a561220R24

**Description**
Change FastMsgIdFn type accordingly