### PR TITLE
feat: implement putUnsafe() for time cache

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1132,8 +1132,9 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements Initiali
     const msgIdStr = this.msgIdToStrFn(msgId)
     const messageId = { msgId, msgIdStr }
 
-    // Add the message to the duplicate caches
-    if (fastMsgIdStr !== undefined) this.fastMsgIdCache?.put(fastMsgIdStr, msgIdStr)
+    // Add the message to the duplicate caches, putUnsafe because multiple messages can reach here
+    // with the same fastMsgIdStr due to the hash data collision
+    if (fastMsgIdStr !== undefined) this.fastMsgIdCache?.putUnsafe(fastMsgIdStr, msgIdStr)
 
     if (this.seenCache.has(msgIdStr)) {
       return { code: MessageStatus.duplicate, msgIdStr }

--- a/src/utils/time-cache.ts
+++ b/src/utils/time-cache.ts
@@ -27,8 +27,22 @@ export class SimpleTimeCache<T> {
     return this.entries.size
   }
 
+  /**
+   * Consumer should check for has() or get() before using this api.
+   */
   put(key: string | number, value: T): void {
     this.entries.set(key, { value, validUntilMs: Date.now() + this.validityMs })
+  }
+
+  /**
+   * Similar to put but if there's an old entry, it'd delete old entry first.
+   * This is to ensure validUntilMs is in ascending order in order to prune
+   * to avoid memory leak.
+   * See https://github.com/ChainSafe/js-libp2p-gossipsub/issues/356
+   */
+  putUnsafe(key: string | number, value: T): void {
+    if (this.has(key)) this.entries.delete(key)
+    this.put(key, value)
   }
 
   prune(): void {
@@ -44,7 +58,7 @@ export class SimpleTimeCache<T> {
     }
   }
 
-  has(key: string): boolean {
+  has(key: string | number): boolean {
     return this.entries.has(key)
   }
 

--- a/test/benchmark/time-cache.test.ts
+++ b/test/benchmark/time-cache.test.ts
@@ -24,5 +24,9 @@ describe('npm TimeCache vs SimpleTimeCache', () => {
     itBench(`SimpleTimeCache.put x${iteration}`, () => {
       for (let j = 0; j < iteration; j++) simpleTimeCache.put(String(j), true)
     })
+
+    itBench(`SimpleTimeCache.putUnsafe x${iteration}`, () => {
+      for (let j = 0; j < iteration; j++) simpleTimeCache.putUnsafe(String(j), true)
+    })
   }
 })

--- a/test/time-cache.spec.ts
+++ b/test/time-cache.spec.ts
@@ -15,7 +15,7 @@ describe('SimpleTimeCache', () => {
     sandbox.restore()
   })
 
-  it('should delete items after 1sec', () => {
+  it('put - should delete items after 1sec', () => {
     timeCache.put('aFirst')
     timeCache.put('bFirst')
     timeCache.put('cFirst')
@@ -37,6 +37,38 @@ describe('SimpleTimeCache', () => {
     expect(timeCache.has('bSecond')).to.be.true()
     expect(timeCache.has('cSecond')).to.be.true()
     expect(timeCache.has('aFirst')).to.be.false()
+    expect(timeCache.has('bFirst')).to.be.false()
+    expect(timeCache.has('cFirst')).to.be.false()
+  })
+
+  it('putUnsafe - should delete items after 1sec', () => {
+    timeCache.putUnsafe('aFirst')
+    timeCache.putUnsafe('bFirst')
+    timeCache.putUnsafe('cFirst')
+
+    expect(timeCache.has('aFirst')).to.be.true()
+    expect(timeCache.has('bFirst')).to.be.true()
+    expect(timeCache.has('cFirst')).to.be.true()
+
+    sandbox.clock.tick(validityMs * 0.5)
+
+    // should delete the old item and recreate new
+    timeCache.putUnsafe('aFirst')
+
+    sandbox.clock.tick(validityMs * 0.5 + 1)
+
+    // https://github.com/ChainSafe/js-libp2p-gossipsub/issues/232#issuecomment-1109589919
+    timeCache.prune()
+
+    timeCache.putUnsafe('aSecond')
+    timeCache.putUnsafe('bSecond')
+    timeCache.putUnsafe('cSecond')
+
+    expect(timeCache.has('aSecond')).to.be.true()
+    expect(timeCache.has('bSecond')).to.be.true()
+    expect(timeCache.has('cSecond')).to.be.true()
+    // should still has aFirst while bFirst and cFirst are deleted
+    expect(timeCache.has('aFirst')).to.be.true()
     expect(timeCache.has('bFirst')).to.be.false()
     expect(timeCache.has('cFirst')).to.be.false()
   })


### PR DESCRIPTION
**Motivation**
- There is memory leak issue in the case of `fastMsgIdFn` hash function data collision, which causes `validUntilMs` to be not in ascending order and `prune` function does not work well
- It's not only happen in #356, I think the current version of lodestar (v1.1.0) also has this issue that's why we have this pattern

<img width="1200" alt="Screen Shot 2022-10-07 at 15 38 12" src="https://user-images.githubusercontent.com/10568965/194510920-648761af-dcd3-492d-802c-f2ff61b271f6.png">

In very bad case `fastMsgIdCache` could grow a lot.

**Description**
- Implement `putUnsafe()` function
- It's noticed that the `putUnsafe()` is 2x slower than `put()`

**TODO**
- [ ] Test in a node for some time