### PR TITLE
chore: bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/libp2p-gossipsub",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "A typescript implementation of gossipsub",
   "leadMaintainer": "Cayman Nava <caymannava@gmail.com>",
   "files": [


### PR DESCRIPTION
CI had a problem bumping the version after https://github.com/ChainSafe/js-libp2p-gossipsub/pull/360