### PR TITLE
fix: mark import as type

### DIFF
--- a/src/message/decodeRpc.ts
+++ b/src/message/decodeRpc.ts
@@ -1,4 +1,4 @@
-import { IRPC, RPC } from './rpc'
+import type { IRPC, RPC } from './rpc'
 import protobuf from 'protobufjs/minimal.js'
 
 export type DecodeRPCLimits = {


### PR DESCRIPTION
[This line](https://github.com/ChainSafe/js-libp2p-gossipsub/blob/master/package.json#L40) copies all files from the `src/messages` folder into `dist` including this `.ts` file, which can then end up getting compiled which depending on your setup fails with:

```
./node_modules/@chainsafe/libp2p-gossipsub/dist/src/message/decodeRpc.ts(1,1): error TS1371: This import is never used as a value and must use 'import type' because 'importsNotUsedAsValues' is set to 'error'.
```

The change here is to mark it `import type` as per the error.  An alternative (better?) would be to not copy it into `dist`, either way would solve the problem.