### PR TITLE
fix: add .js extension to imported file

### DIFF
--- a/src/message/decodeRpc.ts
+++ b/src/message/decodeRpc.ts
@@ -1,4 +1,4 @@
-import type { IRPC, RPC } from './rpc'
+import type { IRPC, RPC } from './rpc.js'
 import protobuf from 'protobufjs/minimal.js'
 
 export type DecodeRPCLimits = {


### PR DESCRIPTION
Added `.js` extension to imported file since compiler gives an error:

 `Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './rpc.js'?` 

with `"moduleResolution"` option set to `"NodeNext"`