### PR TITLE
fix: sync leave() function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1758,9 +1758,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
       }
     }
 
-    this.leave(topic).catch((err) => {
-      this.log(err)
-    })
+    this.leave(topic)
   }
 
   /**
@@ -1834,7 +1832,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
   /**
    * Leave topic
    */
-  private async leave(topic: TopicStr): Promise<void> {
+  private leave(topic: TopicStr): void {
     if (this.status.code !== GossipStatusCode.started) {
       throw new Error('Gossipsub has not started')
     }
@@ -1843,15 +1841,17 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
     this.metrics?.onLeave(topic)
 
     // Send PRUNE to mesh peers
+    this.mesh.delete(topic)
     const meshPeers = this.mesh.get(topic)
     if (meshPeers) {
-      await Promise.all(
+      Promise.all(
         Array.from(meshPeers).map(async (id) => {
           this.log('LEAVE: Remove mesh link to %s in %s', id, topic)
           return await this.sendPrune(id, topic)
         })
-      )
-      this.mesh.delete(topic)
+      ).catch((err) => {
+        this.log('Error sending prunes to mesh peers', err)
+      })
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1841,7 +1841,6 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
     this.metrics?.onLeave(topic)
 
     // Send PRUNE to mesh peers
-    this.mesh.delete(topic)
     const meshPeers = this.mesh.get(topic)
     if (meshPeers) {
       Promise.all(
@@ -1852,6 +1851,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
       ).catch((err) => {
         this.log('Error sending prunes to mesh peers', err)
       })
+      this.mesh.delete(topic)
     }
   }
 


### PR DESCRIPTION
**Motivation**
- lodestar, as a consumer of gossipsub, has an issue if we `unsubscribe()` and `subscribe()` the same topic immediately, see https://github.com/ChainSafe/lodestar/issues/4818#issuecomment-1331784399
- it's not an issue in v0.14.1 because `leave()` function is sync instead of async as in master

**Description**
- Make `leave()` function as sync

part of https://github.com/ChainSafe/lodestar/issues/4818