### PR TITLE
feat: track pruned messages in tracer

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -469,6 +469,10 @@ export function getMetrics(
       name: 'gossipsub_iwant_promise_broken',
       help: 'Total count of broken IWANT promises'
     }),
+    iwantPromisePruned: register.gauge({
+      name: 'gossipsub_iwant_promise_pruned',
+      help: 'Total count of pruned IWANT promises'
+    }),
     /** Histogram of delivery time of resolved IWANT promises */
     iwantPromiseDeliveryTime: register.histogram({
       name: 'gossipsub_iwant_promise_delivery_seconds',

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -469,9 +469,9 @@ export function getMetrics(
       name: 'gossipsub_iwant_promise_broken',
       help: 'Total count of broken IWANT promises'
     }),
-    iwantPromisePruned: register.gauge({
-      name: 'gossipsub_iwant_promise_pruned',
-      help: 'Total count of pruned IWANT promises'
+    iwantMessagePruned: register.gauge({
+      name: 'gossipsub_iwant_message_pruned',
+      help: 'Total count of pruned IWANT messages'
     }),
     /** Histogram of delivery time of resolved IWANT promises */
     iwantPromiseDeliveryTime: register.histogram({

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -144,17 +144,21 @@ export class IWantTracer {
 
   prune(): void {
     const maxMs = Date.now() - this.requestMsByMsgExpire
+    let count = 0
 
     for (const [k, v] of this.requestMsByMsg.entries()) {
       if (v < maxMs) {
         // messages that stay too long in the requestMsByMsg map, delete
         this.requestMsByMsg.delete(k)
+        count++
       } else {
         // recent messages, keep them
         // sort by insertion order
         break
       }
     }
+
+    this.metrics?.iwantPromisePruned.inc(count)
   }
 
   private trackMessage(msgIdStr: MsgIdStr): void {

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -158,7 +158,7 @@ export class IWantTracer {
       }
     }
 
-    this.metrics?.iwantPromisePruned.inc(count)
+    this.metrics?.iwantMessagePruned.inc(count)
   }
 
   private trackMessage(msgIdStr: MsgIdStr): void {


### PR DESCRIPTION
**Motivation**
- In lodestar, metrics showed there are broken promises but if messages are delivered, they are always on time, i.e. within `gossipsubIWantFollowupMs`
- So I'd like to track messages that are pruned, i.e they're never delivered

**Description**
- add and track `iwantMessagePruned` metric

part of https://github.com/ChainSafe/lodestar/issues/4818