### PR TITLE
fix: tracer to track delivered message if duplicate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1093,6 +1093,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
       case MessageStatus.duplicate:
         // Report the duplicate
         this.score.duplicateMessage(from.toString(), validationResult.msgIdStr, rpcMsg.topic)
+        this.gossipTracer.deliverMessage(validationResult.msgIdStr)
         this.mcache.observeDuplicate(validationResult.msgIdStr, from.toString())
         return
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1093,7 +1093,10 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
       case MessageStatus.duplicate:
         // Report the duplicate
         this.score.duplicateMessage(from.toString(), validationResult.msgIdStr, rpcMsg.topic)
-        this.gossipTracer.deliverMessage(validationResult.msgIdStr)
+        // due to the collision of fastMsgIdFn, 2 different messages may end up the same fastMsgId
+        // so we need to also mark the duplicate message as delivered or the promise is not resolved
+        // and peer gets penalized. See https://github.com/ChainSafe/js-libp2p-gossipsub/pull/385
+        this.gossipTracer.deliverMessage(validationResult.msgIdStr, true)
         this.mcache.observeDuplicate(validationResult.msgIdStr, from.toString())
         return
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -460,6 +460,11 @@ export function getMetrics(
       name: 'gossipsub_iwant_promise_resolved_total',
       help: 'Total count of resolved IWANT promises'
     }),
+    /** Total count of resolved IWANT promises from duplicate messages */
+    iwantPromiseResolvedFromDuplicate: register.gauge({
+      name: 'gossipsub_iwant_promise_resolved_from_duplicate_total',
+      help: 'Total count of resolved IWANT promises from duplicate messages'
+    }),
     /** Total count of peers we have asked IWANT promises that are resolved */
     iwantPromiseResolvedPeers: register.gauge({
       name: 'gossipsub_iwant_promise_resolved_peers',

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -105,7 +105,7 @@ export class IWantTracer {
   /**
    * Someone delivered a message, stop tracking promises for it
    */
-  deliverMessage(msgIdStr: MsgIdStr): void {
+  deliverMessage(msgIdStr: MsgIdStr, isDuplicate = false): void {
     this.trackMessage(msgIdStr)
 
     const expireByPeer = this.promises.get(msgIdStr)
@@ -116,6 +116,7 @@ export class IWantTracer {
 
       if (this.metrics) {
         this.metrics.iwantPromiseResolved.inc(1)
+        if (isDuplicate) this.metrics.iwantPromiseResolvedFromDuplicate.inc(1)
         this.metrics.iwantPromiseResolvedPeers.inc(expireByPeer.size)
       }
     }


### PR DESCRIPTION
**Motivation**
- To investigate broken promises in https://github.com/ChainSafe/lodestar/issues/4818
- Consider this scenario
  - 2 messages have same fastMsgId but different msgIds (collision)
  - node sends IWANT control message and add a promise
  - message 1 comes and being tracked in fastMsgId
  - message 2 (as a response to IWANT) comes, since it has same fastMsgId it's a duplicate we didn't mask as "message delivered" in tracer, and it looks like the other node did not send us the requested messages

**Description**
- call `tracer. deliverMessage()` in the case of message duplicate


part of https://github.com/ChainSafe/lodestar/issues/4818
