### PR TITLE
feat: added allowPublishToZeroPeers as optional param to publish function

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,10 @@ export enum SignaturePolicy {
   StrictNoSign = 'StrictNoSign'
 }
 
+export type PublishOpts = {
+  allowPublishToZeroPeers?: boolean
+}
+
 export enum PublishConfigType {
   Signing,
   Anonymous


### PR DESCRIPTION
Closes https://github.com/ChainSafe/js-libp2p-gossipsub/issues/367

The default for allowPublishToZeroPeers will be false but a user can optionally call with allowPublishToZeroPeers set to true to suppress InsufficientPeers errors