### PR TITLE
fix: ignore new closed connection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -698,7 +698,10 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
    * Registrar notifies an established connection with pubsub protocol
    */
   private onPeerConnected(peerId: PeerId, connection: Connection): void {
-    if (!this.isStarted()) {
+    this.metrics?.newConnectionCount.inc({ status: connection.stat.status })
+    // libp2p may emit a closed connection and never issue peer:disconnect event
+    // see https://github.com/ChainSafe/js-libp2p-gossipsub/issues/398
+    if (!this.isStarted() || connection.stat.status !== 'OPEN') {
       return
     }
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -514,7 +514,7 @@ export function getMetrics(
 
     newConnectionCount: register.gauge<{ status: string }>({
       name: 'gossipsub_new_connection_total',
-      help: 'Ttotal new connection by status',
+      help: 'Total new connection by status',
       labelNames: ['status']
     }),
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -512,6 +512,12 @@ export function getMetrics(
       help: 'Total count of key collisions on fastmsgid cache put'
     }),
 
+    newConnectionCount: register.gauge<{ status: string }>({
+      name: 'gossipsub_new_connection_total',
+      help: 'Ttotal new connection by status',
+      labelNames: ['status']
+    }),
+
     topicStrToLabel: topicStrToLabel,
 
     toTopic(topicStr: TopicStr): TopicLabel {


### PR DESCRIPTION
**Motivation**
- libp2p may emit `peer:connect` with a closed connection and we need to handle that, see https://github.com/libp2p/js-libp2p/issues/1565

**Description**
- Handle that in `onPeerConnected`
- Add a metric to track it

Closes #398