### PR TITLE
feat: allow ignoring PublishError.Duplicate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2022,7 +2022,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
       // This message has already been seen. We don't re-publish messages that have already
       // been published on the network.
       if (ignoreDuplicateMessages) {
-        this.metrics?.onIgnoreDuplicateMsg(topic)
+        this.metrics?.onIgnorePublishedDuplicateMsg(topic)
         return { recipients: [] }
       }
       throw Error('PublishError.Duplicate')

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export interface GossipsubOpts extends GossipsubOptsSpec, PubSubInit {
   /** Do not throw `InsufficientPeers` error if publishing to zero peers */
   allowPublishToZeroPeers: boolean
   /** Do not throw `PublishError.Duplicate` if publishing duplicate messages */
-  allowPublishDuplicates: boolean
+  ignoreDuplicateMessages: boolean
   /** For a single stream, await processing each RPC before processing the next */
   awaitRpcHandler: boolean
   /** For a single RPC, await processing each message before processing the next */
@@ -2016,11 +2016,14 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
     const msgIdStr = this.msgIdToStrFn(msgId)
 
     // Current publish opt takes precedence global opts, while preserving false value
-    const allowPublishDuplicates = opts?.allowPublishDuplicates ?? this.opts.allowPublishDuplicates
+    const ignoreDuplicateMessages = opts?.ignoreDuplicateMessages ?? this.opts.ignoreDuplicateMessages
 
-    if (this.seenCache.has(msgIdStr) && !allowPublishDuplicates) {
+    if (this.seenCache.has(msgIdStr)) {
       // This message has already been seen. We don't re-publish messages that have already
       // been published on the network.
+      if (ignoreDuplicateMessages) {
+        return { recipients: [] }
+      }
       throw Error('PublishError.Duplicate')
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export interface GossipsubOpts extends GossipsubOptsSpec, PubSubInit {
   /** Do not throw `InsufficientPeers` error if publishing to zero peers */
   allowPublishToZeroPeers: boolean
   /** Do not throw `PublishError.Duplicate` if publishing duplicate messages */
-  allowPublishDuplicateMessages: boolean
+  ignoreDuplicatePublishError: boolean
   /** For a single stream, await processing each RPC before processing the next */
   awaitRpcHandler: boolean
   /** For a single RPC, await processing each message before processing the next */
@@ -2016,12 +2016,12 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
     const msgIdStr = this.msgIdToStrFn(msgId)
 
     // Current publish opt takes precedence global opts, while preserving false value
-    const allowPublishDuplicateMessages = opts?.allowPublishDuplicateMessages ?? this.opts.allowPublishDuplicateMessages
+    const ignoreDuplicatePublishError = opts?.ignoreDuplicatePublishError ?? this.opts.ignoreDuplicatePublishError
 
     if (this.seenCache.has(msgIdStr)) {
       // This message has already been seen. We don't re-publish messages that have already
       // been published on the network.
-      if (allowPublishDuplicateMessages) {
+      if (ignoreDuplicatePublishError) {
         this.metrics?.onPublishDuplicateMsg(topic)
         return { recipients: [] }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export interface GossipsubOpts extends GossipsubOptsSpec, PubSubInit {
   /** Do not throw `InsufficientPeers` error if publishing to zero peers */
   allowPublishToZeroPeers: boolean
   /** Do not throw `PublishError.Duplicate` if publishing duplicate messages */
-  ignoreDuplicateMessages: boolean
+  allowPublishDuplicateMessages: boolean
   /** For a single stream, await processing each RPC before processing the next */
   awaitRpcHandler: boolean
   /** For a single RPC, await processing each message before processing the next */
@@ -2016,13 +2016,13 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
     const msgIdStr = this.msgIdToStrFn(msgId)
 
     // Current publish opt takes precedence global opts, while preserving false value
-    const ignoreDuplicateMessages = opts?.ignoreDuplicateMessages ?? this.opts.ignoreDuplicateMessages
+    const allowPublishDuplicateMessages = opts?.allowPublishDuplicateMessages ?? this.opts.allowPublishDuplicateMessages
 
     if (this.seenCache.has(msgIdStr)) {
       // This message has already been seen. We don't re-publish messages that have already
       // been published on the network.
-      if (ignoreDuplicateMessages) {
-        this.metrics?.onIgnorePublishedDuplicateMsg(topic)
+      if (allowPublishDuplicateMessages) {
+        this.metrics?.onPublishDuplicateMsg(topic)
         return { recipients: [] }
       }
       throw Error('PublishError.Duplicate')

--- a/src/index.ts
+++ b/src/index.ts
@@ -2022,6 +2022,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
       // This message has already been seen. We don't re-publish messages that have already
       // been published on the network.
       if (ignoreDuplicateMessages) {
+        this.metrics?.onIgnoreDuplicateMsg(topic)
         return { recipients: [] }
       }
       throw Error('PublishError.Duplicate')

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -355,6 +355,12 @@ export function getMetrics(
       labelNames: ['topic']
     }),
 
+    duplicateMsgIgnored: register.gauge<{ topic: TopicLabel }>({
+      name: 'gossisub_duplicate_msg_ignored_total',
+      help: 'Total count of duplicate message ignored by topic',
+      labelNames: ['topic']
+    }),
+
     /* Metrics related to scoring */
     /** Total times score() is called */
     scoreFnCalls: register.gauge({
@@ -627,6 +633,11 @@ export function getMetrics(
         const topic = this.toTopic(topicStr)
         this.duplicateMsgLateDelivery.inc({ topic }, 1)
       }
+    },
+
+    onIgnoreDuplicateMsg(topicStr: TopicStr): void {
+      const topic = this.toTopic(topicStr)
+      this.duplicateMsgIgnored.inc({ topic }, 1)
     },
 
     onRpcRecv(rpc: IRPC, rpcBytes: number): void {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -356,7 +356,7 @@ export function getMetrics(
     }),
 
     duplicateMsgIgnored: register.gauge<{ topic: TopicLabel }>({
-      name: 'gossisub_published_duplicate_msgs_ignored_total',
+      name: 'gossisub_ignored_published_duplicate_msgs_total',
       help: 'Total count of published duplicate message ignored by topic',
       labelNames: ['topic']
     }),

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -635,7 +635,7 @@ export function getMetrics(
       }
     },
 
-    onIgnorePublishedDuplicateMsg(topicStr: TopicStr): void {
+    onPublishDuplicateMsg(topicStr: TopicStr): void {
       const topic = this.toTopic(topicStr)
       this.duplicateMsgIgnored.inc({ topic }, 1)
     },

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -356,8 +356,8 @@ export function getMetrics(
     }),
 
     duplicateMsgIgnored: register.gauge<{ topic: TopicLabel }>({
-      name: 'gossisub_duplicate_msg_ignored_total',
-      help: 'Total count of duplicate message ignored by topic',
+      name: 'gossisub_published_duplicate_msgs_ignored_total',
+      help: 'Total count of published duplicate message ignored by topic',
       labelNames: ['topic']
     }),
 
@@ -635,7 +635,7 @@ export function getMetrics(
       }
     },
 
-    onIgnoreDuplicateMsg(topicStr: TopicStr): void {
+    onIgnorePublishedDuplicateMsg(topicStr: TopicStr): void {
       const topic = this.toTopic(topicStr)
       this.duplicateMsgIgnored.inc({ topic }, 1)
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export enum SignaturePolicy {
 
 export type PublishOpts = {
   allowPublishToZeroPeers?: boolean
-allowPublishDuplicateMessages?: boolean
+  allowPublishDuplicateMessages?: boolean
 }
 
 export enum PublishConfigType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export enum SignaturePolicy {
 
 export type PublishOpts = {
   allowPublishToZeroPeers?: boolean
-  ignoreDuplicateMessages?: boolean
+allowPublishDuplicateMessages?: boolean
 }
 
 export enum PublishConfigType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export enum SignaturePolicy {
 
 export type PublishOpts = {
   allowPublishToZeroPeers?: boolean
-  allowPublishDuplicates?: boolean
+  ignoreDuplicateMessages?: boolean
 }
 
 export enum PublishConfigType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export enum SignaturePolicy {
 
 export type PublishOpts = {
   allowPublishToZeroPeers?: boolean
-  allowPublishDuplicateMessages?: boolean
+  ignoreDuplicatePublishError?: boolean
 }
 
 export enum PublishConfigType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,7 @@ export enum SignaturePolicy {
 
 export type PublishOpts = {
   allowPublishToZeroPeers?: boolean
+  allowPublishDuplicates?: boolean
 }
 
 export enum PublishConfigType {


### PR DESCRIPTION
Closes https://github.com/ChainSafe/js-libp2p-gossipsub/issues/402

When `ignoreDuplicatePublishError` is set, instead of throwing with `PublishError.Duplicate`, simply return.