### PR TITLE
feat: make log as protected

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -354,6 +354,11 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
   public readonly topicValidators = new Map<TopicStr, TopicValidatorFn>()
 
   /**
+   * Make this protected so child class may want to redirect to its own log.
+   */
+  protected readonly log: Logger
+
+  /**
    * Number of heartbeats since the beginning of time
    * This allows us to amortize some resource cleanup -- eg: backoff cleanup
    */
@@ -367,7 +372,6 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
   private readonly components: GossipSubComponents
 
   private directPeerInitial: ReturnType<typeof setTimeout> | null = null
-  private readonly log: Logger
 
   public static multicodec: string = constants.GossipsubIDv11
 


### PR DESCRIPTION
**Motivation**
Lodestar wants to incorporate gossipsub log to its own log files

**Description**
- According to https://github.com/debug-js/debug#output-streams we should be able to configure per-namespace by overriding the `log` method, however when I tried in lodestar it does not work and we have to use the same log instance
- Change `log` from private to protected so that child class can access and redirect to its own log

Closes #406