### PR TITLE
fix: add rpc error metrics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -969,7 +969,22 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
       return
     }
 
-    this.log('rpc from %p', from)
+    const subscriptions = rpc.subscriptions ? rpc.subscriptions.length : 0
+    const messages = rpc.messages ? rpc.messages.length : 0
+    let ihave = 0
+    let iwant = 0
+    let graft = 0
+    let prune = 0
+    if (rpc.control) {
+      ihave = rpc.control.ihave ? rpc.control.ihave.length : 0
+      iwant = rpc.control.iwant ? rpc.control.iwant.length : 0
+      graft = rpc.control.graft ? rpc.control.graft.length : 0
+      prune = rpc.control.prune ? rpc.control.prune.length : 0
+    }
+    // this.log('rpc from %p', from)
+    this.log(
+      `rpc.from ${from.toString()} subscriptions ${subscriptions} messages ${messages} ihave ${ihave} iwant ${iwant} graft ${graft} prune ${prune}`
+    )
 
     // Handle received subscriptions
     if (rpc.subscriptions && rpc.subscriptions.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1037,7 +1037,10 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
 
         const handleReceivedMessagePromise = this.handleReceivedMessage(from, message)
           // Should never throw, but handle just in case
-          .catch((err) => this.log(err))
+          .catch((err) => {
+            this.metrics?.onMsgRecvError(message.topic)
+            this.log(err)
+          })
 
         if (this.opts.awaitRpcMessageHandler) {
           await handleReceivedMessagePromise

--- a/src/index.ts
+++ b/src/index.ts
@@ -986,10 +986,10 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
     let graft = 0
     let prune = 0
     if (rpc.control) {
-      ihave = rpc.control.ihave ? rpc.control.ihave.length : 0
-      iwant = rpc.control.iwant ? rpc.control.iwant.length : 0
-      graft = rpc.control.graft ? rpc.control.graft.length : 0
-      prune = rpc.control.prune ? rpc.control.prune.length : 0
+      if (rpc.control.ihave) ihave = rpc.control.ihave.length
+      if (rpc.control.iwant) iwant = rpc.control.iwant.length
+      if (rpc.control.graft) graft = rpc.control.graft.length
+      if (rpc.control.prune) prune = rpc.control.prune.length
     }
     this.log(
       `rpc.from ${from.toString()} subscriptions ${subscriptions} messages ${messages} ihave ${ihave} iwant ${iwant} graft ${graft} prune ${prune}`

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -331,6 +331,12 @@ export function getMetrics(
       help: 'Total count of recv msgs before any validation',
       labelNames: ['topic']
     }),
+    /** Total count of recv msgs error */
+    msgReceivedError: register.gauge<{ topic: TopicLabel }>({
+      name: 'gossipsub_msg_received_error_total',
+      help: 'Total count of recv msgs error',
+      labelNames: ['topic']
+    }),
     /** Tracks distribution of recv msgs by duplicate, invalid, valid */
     msgReceivedStatus: register.gauge<{ topic: TopicLabel; status: MessageStatus }>({
       name: 'gossipsub_msg_received_status_total',
@@ -621,6 +627,11 @@ export function getMetrics(
     onMsgRecvPreValidation(topicStr: TopicStr): void {
       const topic = this.toTopic(topicStr)
       this.msgReceivedPreValidation.inc({ topic }, 1)
+    },
+
+    onMsgRecvError(topicStr: TopicStr): void {
+      const topic = this.toTopic(topicStr)
+      this.msgReceivedError.inc({ topic }, 1)
     },
 
     onMsgRecvResult(topicStr: TopicStr, status: MessageStatus): void {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -249,6 +249,12 @@ export function getMetrics(
       labelNames: ['hit']
     }),
 
+    // peer stream
+    peerReadStreamError: register.gauge({
+      name: 'gossipsub_peer_read_stream_err_count_total',
+      help: 'Peer read stream error'
+    }),
+
     // RPC outgoing. Track byte length + data structure sizes
     rpcRecvBytes: register.gauge({ name: 'gossipsub_rpc_recv_bytes_total', help: 'RPC recv' }),
     rpcRecvCount: register.gauge({ name: 'gossipsub_rpc_recv_count_total', help: 'RPC recv' }),
@@ -259,6 +265,8 @@ export function getMetrics(
     rpcRecvIWant: register.gauge({ name: 'gossipsub_rpc_recv_iwant_total', help: 'RPC recv' }),
     rpcRecvGraft: register.gauge({ name: 'gossipsub_rpc_recv_graft_total', help: 'RPC recv' }),
     rpcRecvPrune: register.gauge({ name: 'gossipsub_rpc_recv_prune_total', help: 'RPC recv' }),
+    rpcDataError: register.gauge({ name: 'gossipsub_rpc_data_err_count_total', help: 'RPC data error' }),
+    rpcRecvError: register.gauge({ name: 'gossipsub_rpc_recv_err_count_total', help: 'RPC recv error' }),
 
     /** Total count of RPC dropped because acceptFrom() == false */
     rpcRecvNotAccepted: register.gauge({
@@ -638,6 +646,18 @@ export function getMetrics(
     onPublishDuplicateMsg(topicStr: TopicStr): void {
       const topic = this.toTopic(topicStr)
       this.duplicateMsgIgnored.inc({ topic }, 1)
+    },
+
+    onPeerReadStreamError(): void {
+      this.peerReadStreamError.inc(1)
+    },
+
+    onRpcRecvError(): void {
+      this.rpcRecvError.inc(1)
+    },
+
+    onRpcDataError(): void {
+      this.rpcDataError.inc(1)
     },
 
     onRpcRecv(rpc: IRPC, rpcBytes: number): void {


### PR DESCRIPTION
**Motivation**
- There are rpc errors that's not tracked in metrics and it caused missed messages from other peers
- See https://github.com/ChainSafe/js-libp2p-gossipsub/issues/411#issue-1610585138

**Description**
- Add more logs for rpc message
- Add metrics when handling errors

part of #411

It shows that we really have rpc errors when deploying this branch to a lodestar node
<img width="1296" alt="Screen Shot 2023-03-07 at 10 10 16" src="https://user-images.githubusercontent.com/10568965/223310598-2da4d576-94c8-4928-b945-acc7e052e869.png">

