### PR TITLE
fix: track promise only after a successful sendRpc()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1244,7 +1244,11 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
       return
     }
 
-    this.sendRpc(id, { messages: ihave, control: { iwant, prune } })
+    const sent = this.sendRpc(id, { messages: ihave, control: { iwant, prune } })
+    const iwantMessageIds = iwant[0]?.messageIDs
+    if (sent && iwantMessageIds) {
+      this.gossipTracer.addPromise(id, iwantMessageIds)
+    }
   }
 
   /**
@@ -1354,7 +1358,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
     iwantList = iwantList.slice(0, iask)
     this.iasked.set(id, iasked + iask)
 
-    this.gossipTracer.addPromise(id, iwantList)
+    // do not add promise here until a successful sendRpc()
 
     return [
       {


### PR DESCRIPTION
**Motivation**
- In rare case, a `sendRpc()` call may be failed or got delayed, we should only track promise after a successful `sendRpc`

part of #413