### PR TITLE
fix!: reportMessageValidationResult to accept peer id string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2139,7 +2139,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
    *
    * This should only be called once per message.
    */
-  reportMessageValidationResult(msgId: MsgIdStr, propagationSource: PeerId, acceptance: TopicValidatorResult): void {
+  reportMessageValidationResult(msgId: MsgIdStr, propagationSource: PeerIdStr, acceptance: TopicValidatorResult): void {
     let cacheEntry: MessageCacheRecord | null
 
     if (acceptance === TopicValidatorResult.Accept) {
@@ -2148,9 +2148,9 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
       if (cacheEntry != null) {
         const { message: rawMsg, originatingPeers } = cacheEntry
         // message is fully validated inform peer_score
-        this.score.deliverMessage(propagationSource.toString(), msgId, rawMsg.topic)
+        this.score.deliverMessage(propagationSource, msgId, rawMsg.topic)
 
-        this.forwardMessage(msgId, cacheEntry.message, propagationSource.toString(), originatingPeers)
+        this.forwardMessage(msgId, cacheEntry.message, propagationSource, originatingPeers)
       }
       // else, Message not in cache. Ignoring forwarding
     }
@@ -2165,7 +2165,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
 
         // Tell peer_score about reject
         // Reject the original source, and any duplicates we've seen from other peers.
-        this.score.rejectMessage(propagationSource.toString(), msgId, rawMsg.topic, rejectReason)
+        this.score.rejectMessage(propagationSource, msgId, rawMsg.topic, rejectReason)
         for (const peer of originatingPeers) {
           this.score.rejectMessage(peer, msgId, rawMsg.topic, rejectReason)
         }


### PR DESCRIPTION
**Motivation**
- In lodestar, passing peer id through thread boundary has to be in string, it has to convert back to a `PeerId` instance at lodestar side and `reportMessageValidationResult` to call `toString()` again, it causes lodestar network thread to waste 2.8% of cpu time

<img width="1316" alt="Screenshot 2023-06-12 at 10 42 28" src="https://github.com/ChainSafe/js-libp2p-gossipsub/assets/10568965/2668d506-8afc-4010-af2a-c53d0cab6f51">

**Description**
- reportMessageValidationResult to accept peer id string instead, it's a breaking change

part of https://github.com/ChainSafe/lodestar/issues/5604