### PR TITLE
feat: track async validation delay from first seen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainsafe/libp2p-gossipsub",
-  "version": "8.0.1",
+  "version": "8.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { createTopology } from '@libp2p/topology'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import { CustomEvent, EventEmitter } from '@libp2p/interfaces/events'
 
-import { MessageCache } from './message-cache.js'
+import { MessageCache, MessageCacheRecord } from './message-cache.js'
 import { RPC, IRPC } from './message/rpc.js'
 import * as constants from './constants.js'
 import { shuffle, messageIdToString } from './utils/index.js'
@@ -2140,9 +2140,10 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
    * This should only be called once per message.
    */
   reportMessageValidationResult(msgId: MsgIdStr, propagationSource: PeerId, acceptance: TopicValidatorResult): void {
+    let cacheEntry: MessageCacheRecord | null
+
     if (acceptance === TopicValidatorResult.Accept) {
-      const cacheEntry = this.mcache.validate(msgId)
-      this.metrics?.onReportValidationMcacheHit(cacheEntry !== null)
+      cacheEntry = this.mcache.validate(msgId)
 
       if (cacheEntry != null) {
         const { message: rawMsg, originatingPeers } = cacheEntry
@@ -2150,15 +2151,13 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
         this.score.deliverMessage(propagationSource.toString(), msgId, rawMsg.topic)
 
         this.forwardMessage(msgId, cacheEntry.message, propagationSource.toString(), originatingPeers)
-        this.metrics?.onReportValidation(rawMsg.topic, acceptance)
       }
       // else, Message not in cache. Ignoring forwarding
     }
 
     // Not valid
     else {
-      const cacheEntry = this.mcache.remove(msgId)
-      this.metrics?.onReportValidationMcacheHit(cacheEntry !== null)
+      cacheEntry = this.mcache.remove(msgId)
 
       if (cacheEntry) {
         const rejectReason = rejectReasonFromAcceptance(acceptance)
@@ -2170,11 +2169,12 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
         for (const peer of originatingPeers) {
           this.score.rejectMessage(peer, msgId, rawMsg.topic, rejectReason)
         }
-
-        this.metrics?.onReportValidation(rawMsg.topic, acceptance)
       }
       // else, Message not in cache. Ignoring forwarding
     }
+
+    const firstSeenTimestampMs = this.score.messageFirstSeeenTimestampMs(msgId)
+    this.metrics?.onReportValidation(cacheEntry, acceptance, firstSeenTimestampMs)
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2173,7 +2173,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
       // else, Message not in cache. Ignoring forwarding
     }
 
-    const firstSeenTimestampMs = this.score.messageFirstSeeenTimestampMs(msgId)
+    const firstSeenTimestampMs = this.score.messageFirstSeenTimestampMs(msgId)
     this.metrics?.onReportValidation(cacheEntry, acceptance, firstSeenTimestampMs)
   }
 

--- a/src/message-cache.ts
+++ b/src/message-cache.ts
@@ -5,6 +5,8 @@ export type CacheEntry = MessageId & {
   topic: TopicStr
 }
 
+export type MessageCacheRecord = Pick<MessageCacheEntry, 'message' | 'originatingPeers'>
+
 interface MessageCacheEntry {
   message: RPC.IMessage
   /**
@@ -144,7 +146,7 @@ export class MessageCache {
    * This function also returns the known peers that have sent us this message. This is used to
    * prevent us sending redundant messages to peers who have already propagated it.
    */
-  validate(msgId: MsgIdStr): { message: RPC.IMessage; originatingPeers: Set<PeerIdStr> } | null {
+  validate(msgId: MsgIdStr): MessageCacheRecord | null {
     const entry = this.msgs.get(msgId)
     if (!entry) {
       return null
@@ -181,7 +183,7 @@ export class MessageCache {
     this.history.unshift([])
   }
 
-  remove(msgId: MsgIdStr): MessageCacheEntry | null {
+  remove(msgId: MsgIdStr): MessageCacheRecord | null {
     const entry = this.msgs.get(msgId)
     if (!entry) {
       return null

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -266,15 +266,15 @@ export function getMetrics(
       labelNames: ['hit']
     }),
 
-    asyncValidationDelayFromFirstSeen: register.histogram<{ topic: TopicLabel }>({
+    asyncValidationDelayFromFirstSeenSec: register.histogram<{ topic: TopicLabel }>({
       name: 'gossipsub_async_validation_delay_from_first_seen',
-      help: 'Async validation report delay from first seen',
+      help: 'Async validation report delay from first seen in second',
       labelNames: ['topic'],
       buckets: [0.01, 0.03, 0.1, 0.3, 1, 3, 10]
     }),
 
     asyncValidationUnknownFirstSeen: register.gauge({
-      name: 'gossipsub_async_validation_unknown_first_seen',
+      name: 'gossipsub_async_validation_unknown_first_seen_count_total',
       help: 'Async validation report unknown first seen value for message'
     }),
 
@@ -619,7 +619,10 @@ export function getMetrics(
       this.meshPeerChurnEventsByTopic.inc({ topic }, count)
     },
 
-    // null messageRecord means the message's mcache record was not known at the time of acceptance report
+    /**
+     * Update validation result to metrics
+     * @param messageRecord null means the message's mcache record was not known at the time of acceptance report
+     */
     onReportValidation(
       messageRecord: { message: { topic: TopicStr } } | null,
       acceptance: TopicValidatorResult,
@@ -634,7 +637,7 @@ export function getMetrics(
       }
 
       if (firstSeenTimestampMs != null) {
-        this.asyncValidationDelayFromFirstSeen.observe((Date.now() - firstSeenTimestampMs) / 1000)
+        this.asyncValidationDelayFromFirstSeenSec.observe((Date.now() - firstSeenTimestampMs) / 1000)
       } else {
         this.asyncValidationUnknownFirstSeen.inc()
       }

--- a/src/score/message-deliveries.ts
+++ b/src/score/message-deliveries.ts
@@ -22,7 +22,7 @@ export enum DeliveryRecordStatus {
 
 export interface DeliveryRecord {
   status: DeliveryRecordStatus
-  firstSeen: number
+  firstSeenTsMs: number
   validated: number
   peers: Set<string>
 }
@@ -46,6 +46,10 @@ export class MessageDeliveries {
     this.queue = new Denque()
   }
 
+  getRecord(msgIdStr: string): DeliveryRecord | undefined {
+    return this.records.get(msgIdStr)
+  }
+
   ensureRecord(msgIdStr: string): DeliveryRecord {
     let drec = this.records.get(msgIdStr)
     if (drec) {
@@ -56,7 +60,7 @@ export class MessageDeliveries {
     // create record
     drec = {
       status: DeliveryRecordStatus.unknown,
-      firstSeen: Date.now(),
+      firstSeenTsMs: Date.now(),
       validated: 0,
       peers: new Set()
     }

--- a/src/score/peer-score.ts
+++ b/src/score/peer-score.ts
@@ -100,6 +100,11 @@ export class PeerScore {
     return Object.fromEntries(Array.from(this.peerStats.entries()).map(([peer, stats]) => [peer, stats]))
   }
 
+  messageFirstSeeenTimestampMs(msgIdStr: MsgIdStr): number | null {
+    const drec = this.deliveryRecords.getRecord(msgIdStr)
+    return drec ? drec.firstSeenTsMs : null
+  }
+
   /**
    * Decays scores, and purges score records for disconnected peers once their expiry has elapsed.
    */
@@ -339,7 +344,7 @@ export class PeerScore {
       log(
         'unexpected delivery: message from %s was first seen %s ago and has delivery status %s',
         from,
-        now - drec.firstSeen,
+        now - drec.firstSeenTsMs,
         DeliveryRecordStatus[drec.status]
       )
       return
@@ -385,7 +390,7 @@ export class PeerScore {
       log(
         'unexpected rejection: message from %s was first seen %s ago and has delivery status %d',
         from,
-        Date.now() - drec.firstSeen,
+        Date.now() - drec.firstSeenTsMs,
         DeliveryRecordStatus[drec.status]
       )
       return

--- a/src/score/peer-score.ts
+++ b/src/score/peer-score.ts
@@ -100,7 +100,7 @@ export class PeerScore {
     return Object.fromEntries(Array.from(this.peerStats.entries()).map(([peer, stats]) => [peer, stats]))
   }
 
-  messageFirstSeeenTimestampMs(msgIdStr: MsgIdStr): number | null {
+  messageFirstSeenTimestampMs(msgIdStr: MsgIdStr): number | null {
     const drec = this.deliveryRecords.getRecord(msgIdStr)
     return drec ? drec.firstSeenTsMs : null
   }


### PR DESCRIPTION
**Motivation**
We want to know how long does it take to validate a message with async validation

**Description**
- Use `firstSeen` field in `MessageDeliveries`
- Add new metrics:
  - `asyncValidationDelayFromFirstSeenSec`
  - `asyncValidationUnknownFirstSeen`