### PR TITLE
fix: unhandle protocol on stop

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -636,6 +636,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
 
     // unregister protocol and handlers
     const registrar = this.components.registrar
+    await Promise.all(this.multicodecs.map((multicodec) => registrar.unhandle(multicodec)))
     registrarTopologyIds.forEach((id) => registrar.unregister(id))
 
     this.outboundInflightQueue.end()


### PR DESCRIPTION
Resolves #437 

Protocol handling has two components, registering inbound and outbound handlers.
It seems that on gossipsub.stop, we were unregistering the outbound handler but NOT properly unregistering the inbound handler.