### PR TITLE
fix: correct metric in handlePrune()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1569,7 +1569,7 @@ export class GossipSub extends EventEmitter<GossipsubEvents> implements PubSub<G
       this.score.prune(id, topicID)
       if (peersInMesh.has(id)) {
         peersInMesh.delete(id)
-        this.metrics?.onRemoveFromMesh(topicID, ChurnReason.Unsub, 1)
+        this.metrics?.onRemoveFromMesh(topicID, ChurnReason.Prune, 1)
       }
 
       // is there a backoff specified by the peer? if so obey it

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -89,8 +89,6 @@ export enum ChurnReason {
   BadScore = 'bad_score',
   /// Peer sent a PRUNE.
   Prune = 'prune',
-  /// Peer unsubscribed.
-  Unsub = 'unsubscribed',
   /// Too many peers.
   Excess = 'excess'
 }


### PR DESCRIPTION
**Motivation**
- We use "Unsubscribed" as a churn reason in handlePrune() which is misleading, because it could mean many different thing:
  - our peer score is bad => peer prunes us
  - it's still in backoff time and we send graft to them => peer prunes us (will open another issue with this)
  - peer has too many mesh peers
  - peer unsubscribes from topic

**Description**
- Use the existing "Prune" reason instead