### PR TITLE
fix: track publish time in second

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -338,10 +338,10 @@ export function getMetrics(
       help: 'Total count of msg publish data.length bytes',
       labelNames: ['topic']
     }),
-    /** Total time in millisecond to publish a message */
+    /** Total time in seconds to publish a message */
     msgPublishTime: register.histogram<{ topic: TopicLabel }>({
       name: 'gossipsub_msg_publish_seconds',
-      help: 'Total time in millisecond to publish a message',
+      help: 'Total time in seconds to publish a message',
       buckets: [0.001, 0.002, 0.005, 0.01, 0.1, 0.5, 1],
       labelNames: ['topic']
     }),

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -339,10 +339,10 @@ export function getMetrics(
       labelNames: ['topic']
     }),
     /** Total time in millisecond to publish a message */
-    msgPublishMs: register.histogram<{ topic: TopicLabel }>({
-      name: 'gossipsub_msg_publish_ms',
+    msgPublishTime: register.histogram<{ topic: TopicLabel }>({
+      name: 'gossipsub_msg_publish_seconds',
       help: 'Total time in millisecond to publish a message',
-      buckets: [1, 2, 5, 10, 100, 500, 1000],
+      buckets: [0.001, 0.002, 0.005, 0.01, 0.1, 0.5, 1],
       labelNames: ['topic']
     }),
 
@@ -705,7 +705,7 @@ export function getMetrics(
       this.msgPublishPeersByGroup.inc({ peerGroup: 'floodsub' }, tosendGroupCount.floodsub)
       this.msgPublishPeersByGroup.inc({ peerGroup: 'mesh' }, tosendGroupCount.mesh)
       this.msgPublishPeersByGroup.inc({ peerGroup: 'fanout' }, tosendGroupCount.fanout)
-      this.msgPublishMs.observe({ topic }, ms)
+      this.msgPublishTime.observe({ topic }, ms / 1000)
     },
 
     onMsgRecvPreValidation(topicStr: TopicStr): void {


### PR DESCRIPTION
**Motivation**
See https://github.com/ChainSafe/js-libp2p-gossipsub/pull/451#discussion_r1269312699

**Description**
Track publish time in second as the convention of Prometheus https://prometheus.io/docs/practices/naming/#base-units