### PR TITLE
fix: runsFactor in benchmark

### DIFF
--- a/test/benchmark/protobuf.test.ts
+++ b/test/benchmark/protobuf.test.ts
@@ -27,21 +27,25 @@ describe('protobuf', function () {
 
   const bytes = RPC.encode(rpc).finish()
 
-  // console.log('@@@ encoded to', Buffer.from(bytes.slice()).toString('hex'), 'length', bytes.length)
+  const runsFactor = 1000
 
   itBench({
     id: 'decode Attestation message using protobufjs',
     fn: () => {
-      RPC.decode(bytes)
+      for (let i = 0; i < runsFactor; i++) {
+        RPC.decode(bytes)
+      }
     },
-    runsFactor: 100
+    runsFactor
   })
 
   itBench({
     id: 'encode Attestation message using protobufjs',
     fn: () => {
-      RPC.encode(rpc).finish()
+      for (let i = 0; i < runsFactor; i++) {
+        RPC.encode(rpc).finish()
+      }
     },
-    runsFactor: 100
+    runsFactor
   })
 })


### PR DESCRIPTION
**Description**

Fix runsFactor in protobuf benchmark. The result on Mac M1:

```
protobuf
    ✔ decode Attestation message using protobufjs                          3310020 ops/s    302.1130 ns/op   x1.003     395672 runs    120 s
    ✔ encode Attestation message using protobufjs                          2419082 ops/s    413.3800 ns/op   x1.040     288753 runs    120 s
```