### PR TITLE
fix: make peer score use component logger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -503,7 +503,7 @@ export class GossipSub extends TypedEventEmitter<GossipsubEvents> implements Pub
     /**
      * libp2p
      */
-    this.score = new PeerScore(this.opts.scoreParams, this.metrics, {
+    this.score = new PeerScore(this.opts.scoreParams, this.metrics, this.components.logger, {
       scoreCacheValidityMs: opts.heartbeatInterval
     })
 

--- a/test/peer-score.spec.ts
+++ b/test/peer-score.spec.ts
@@ -1,3 +1,4 @@
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { expect } from 'aegir/chai'
 import delay from 'delay'
@@ -13,6 +14,8 @@ import type { PeerStats } from '../src/score/peer-stats.js'
 const scorePenaltyAny = ScorePenalty.BrokenPromise
 
 describe('PeerScore', () => {
+  const logger = defaultLogger()
+
   it('should score based on time in mesh', async () => {
     // Create parameters with reasonable default values
     const mytopic = 'mytopic'
@@ -27,7 +30,7 @@ describe('PeerScore', () => {
     }))
     const peerA = (await createEd25519PeerId()).toString()
     // Peer score should start at 0
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     ps.addPeer(peerA)
 
     let aScore = ps.score(peerA)
@@ -56,7 +59,7 @@ describe('PeerScore', () => {
     }))
     const peerA = (await createEd25519PeerId()).toString()
     // Peer score should start at 0
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     ps.addPeer(peerA)
 
     let aScore = ps.score(peerA)
@@ -88,7 +91,7 @@ describe('PeerScore', () => {
     }))
     const peerA = (await createEd25519PeerId()).toString()
     // Peer score should start at 0
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     ps.addPeer(peerA)
     ps.graft(peerA, mytopic)
 
@@ -123,7 +126,7 @@ describe('PeerScore', () => {
     }))
     const peerA = (await createEd25519PeerId()).toString()
     // Peer score should start at 0
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     ps.addPeer(peerA)
 
     let aScore = ps.score(peerA)
@@ -166,7 +169,7 @@ describe('PeerScore', () => {
     }))
     const peerA = (await createEd25519PeerId()).toString()
     // Peer score should start at 0
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     ps.addPeer(peerA)
 
     let aScore = ps.score(peerA)
@@ -229,7 +232,7 @@ describe('PeerScore', () => {
     const peerC = (await createEd25519PeerId()).toString()
     const peers = [peerA, peerB, peerC]
     // Peer score should start at 0
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     peers.forEach((p) => {
       ps.addPeer(p)
       ps.graft(p, mytopic)
@@ -290,7 +293,7 @@ describe('PeerScore', () => {
     }))
     const peerA = (await createEd25519PeerId()).toString()
     // Peer score should start at 0
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     ps.addPeer(peerA)
     ps.graft(peerA, mytopic)
 
@@ -350,7 +353,7 @@ describe('PeerScore', () => {
     const peerA = (await createEd25519PeerId()).toString()
     const peerB = (await createEd25519PeerId()).toString()
     const peers = [peerA, peerB]
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     peers.forEach((p) => {
       ps.addPeer(p)
       ps.graft(p, mytopic)
@@ -398,7 +401,7 @@ describe('PeerScore', () => {
       timeInMeshWeight: 0
     }))
     const peerA = (await createEd25519PeerId()).toString()
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     ps.addPeer(peerA)
     ps.graft(peerA, mytopic)
 
@@ -429,7 +432,7 @@ describe('PeerScore', () => {
       timeInMeshWeight: 0
     }))
     const peerA = (await createEd25519PeerId()).toString()
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     ps.addPeer(peerA)
     ps.graft(peerA, mytopic)
 
@@ -469,7 +472,7 @@ describe('PeerScore', () => {
     })
     const peerA = (await createEd25519PeerId()).toString()
     const peerB = (await createEd25519PeerId()).toString()
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     ps.addPeer(peerA)
     ps.addPeer(peerB)
 
@@ -547,7 +550,7 @@ describe('PeerScore', () => {
       appSpecificWeight: 0.5
     })
     const peerA = (await createEd25519PeerId()).toString()
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     ps.addPeer(peerA)
     ps.graft(peerA, mytopic)
 
@@ -572,7 +575,7 @@ describe('PeerScore', () => {
     const peerD = (await createEd25519PeerId()).toString()
     const peers = [peerA, peerB, peerC, peerD]
 
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     peers.forEach((p) => {
       ps.addPeer(p)
       ps.graft(p, mytopic)
@@ -613,7 +616,7 @@ describe('PeerScore', () => {
     })
     const peerA = (await createEd25519PeerId()).toString()
 
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
 
     // add penalty on a non-existent peer
     ps.addPenalty(peerA, 1, ScorePenalty.MessageDeficit)
@@ -649,7 +652,7 @@ describe('PeerScore', () => {
     })
     const peerA = (await createEd25519PeerId()).toString()
 
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     ps.addPeer(peerA)
     ps.graft(peerA, mytopic)
     // score should equal -1000 (app-specific score)
@@ -678,6 +681,7 @@ describe('PeerScore', () => {
 // TODO: https://github.com/ChainSafe/js-libp2p-gossipsub/issues/238
 describe.skip('PeerScore score cache', function () {
   const peerA = '16Uiu2HAmMkH6ZLen2tbhiuNCTZLLvrZaDgufNdT5MPjtC9Hr9YNG'
+  const logger = defaultLogger()
   let sandbox: sinon.SinonSandbox
   let computeStoreStub: sinon.SinonStub<[string, PeerStats, PeerScoreParams, Map<string, Set<string>>], number>
   const params = createPeerScoreParams({
@@ -696,7 +700,7 @@ describe.skip('PeerScore score cache', function () {
     sandbox.useFakeTimers(now)
     computeStoreStub = sinon.stub<[string, PeerStats, PeerScoreParams, Map<string, Set<string>>], number>()
 
-    ps2 = new PeerScore(params, null, {
+    ps2 = new PeerScore(params, null, logger, {
       scoreCacheValidityMs: 10,
       computeScore: computeStoreStub
     })

--- a/test/scoreMetrics.spec.ts
+++ b/test/scoreMetrics.spec.ts
@@ -1,3 +1,4 @@
+import { defaultLogger } from '@libp2p/logger'
 import { createEd25519PeerId } from '@libp2p/peer-id-factory'
 import { expect } from 'aegir/chai'
 import { ScorePenalty } from '../src/metrics.js'
@@ -5,6 +6,8 @@ import { createPeerScoreParams, createTopicScoreParams, PeerScore } from '../src
 import { computeAllPeersScoreWeights } from '../src/score/scoreMetrics.js'
 
 describe('score / scoreMetrics', () => {
+  const logger = defaultLogger()
+
   it('computeScoreWeights', async () => {
     // Create parameters with reasonable default values
     const topic = 'test_topic'
@@ -25,7 +28,7 @@ describe('score / scoreMetrics', () => {
 
     const peerA = (await createEd25519PeerId()).toString()
     // Peer score should start at 0
-    const ps = new PeerScore(params, null, { scoreCacheValidityMs: 0 })
+    const ps = new PeerScore(params, null, logger, { scoreCacheValidityMs: 0 })
     ps.addPeer(peerA)
 
     // Do some actions that penalize the peer


### PR DESCRIPTION
Follow up to #473 - makes `PeerScore` use the configured component logger instead of creating a new one.