### PR TITLE
fix: remove abortable iterator

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "@libp2p/peer-id": "^4.0.5",
     "@libp2p/pubsub": "^9.0.8",
     "@multiformats/multiaddr": "^12.1.14",
-    "abortable-iterator": "^5.0.1",
     "denque": "^2.1.0",
     "it-length-prefixed": "^9.0.4",
     "it-pipe": "^3.0.1",


### PR DESCRIPTION
AbortableSource is slow because it races promises against every chunk causing extra async work.

It's only really necessary if we're going to pass the source off to another component.

Here we don't do that so it's simpler to just add a listener for the abort event and close the stream.