### PR TITLE
feat: publish at least mesh_n peers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2037,6 +2037,8 @@ export class GossipSub extends TypedEventEmitter<GossipsubEvents> implements Pub
             tosendCount.mesh++
           })
 
+          // We want to publish to at least `D` peers.
+          // If there are insufficient peers in the mesh, publish to other topic peers
           if (meshPeers.size < this.opts.D) {
             // pick additional topic peers above the publishThreshold
             const topicPeers = this.getRandomGossipPeers(topic, this.opts.D - meshPeers.size, (id) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2036,6 +2036,18 @@ export class GossipSub extends TypedEventEmitter<GossipsubEvents> implements Pub
             tosend.add(peer)
             tosendCount.mesh++
           })
+
+          if (meshPeers.size < this.opts.D) {
+            // pick additional topic peers above the publishThreshold
+            const topicPeers = this.getRandomGossipPeers(topic, this.opts.D - meshPeers.size, (id) => {
+              return !meshPeers.has(id) && !this.direct.has(id) && !this.floodsubPeers.has(id) && this.score.score(id) >= this.opts.scoreThresholds.publishThreshold
+            })
+
+            topicPeers.forEach((peer) => {
+              tosend.add(peer)
+              tosendCount.mesh++
+            })
+          }
         // eslint-disable-next-line @typescript-eslint/brace-style
         }
 


### PR DESCRIPTION
**Motivation**
- Lodestar may want to set `floodPublish` as false in the future

**Description**
- In that case we want to publish at least `mesh_n` peers

see https://github.com/ChainSafe/lodestar/issues/6596#issuecomment-2021834289