### PR TITLE
fix: remove CustomEvent import

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node: [16]
+        node: [lts/*]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [16]
+        node: [lts/*]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: npm install
-      - run: npm run test:e2e -- --target node --bail -- --exit 
+      - run: npm run test:e2e -- --target node --bail -- --exit
   test-chrome:
     needs: check
     runs-on: ubuntu-latest
@@ -76,29 +76,29 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: [check, test-node, test-chrome]
     steps:
-      - uses: google-github-actions/release-please-action@v3 
+      - uses: google-github-actions/release-please-action@v3
         id: release
         with:
           release-type: node
           package-name: release-please-action
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false}]'
-      
+
       - uses: actions/checkout@v3
         if: ${{ steps.release.outputs.release_created }}
-        
+
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
-      
+
       - run: npm install
         if: ${{ steps.release.outputs.release_created }}
-      
+
       - run: npm run build
         if: ${{ steps.release.outputs.release_created }}
 
-      - run: npm publish --access public 
+      - run: npm publish --access public
         if: ${{ steps.release.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { CustomEvent, TypedEventEmitter, StrictSign, StrictNoSign, TopicValidatorResult, serviceCapabilities, serviceDependencies } from '@libp2p/interface'
+import { TypedEventEmitter, StrictSign, StrictNoSign, TopicValidatorResult, serviceCapabilities, serviceDependencies } from '@libp2p/interface'
 import { peerIdFromBytes, peerIdFromString } from '@libp2p/peer-id'
 import { encode } from 'it-length-prefixed'
 import { pipe } from 'it-pipe'


### PR DESCRIPTION
`CustomEvent` is [global as of Node.js 18.7.0](https://nodejs.org/docs/latest/api/globals.html#customevent) and the polyfill will be removed in `libp2p@2.x.x` so remove the import here for forwards compatibility with the js-libp2p monorepo.