### PR TITLE
feat: add ethereum/beacon-metrics per spec

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1212,11 +1212,12 @@ export class GossipSub extends TypedEventEmitter<GossipsubEvents> implements Pub
    * May forward to all peers in the mesh.
    */
   private async handleReceivedMessage (from: PeerId, rpcMsg: RPC.Message): Promise<void> {
-    this.metrics?.onMsgRecvPreValidation(rpcMsg.topic)
+    const topic = this.metrics?.toTopic(rpcMsg.topic) ?? ''
+    const messageBytes = RPC.Message.getSize(rpcMsg)
 
+    this.metrics?.onMsgRecvPreValidation(topic, messageBytes)
     const validationResult = await this.validateReceivedMessage(from, rpcMsg)
-
-    this.metrics?.onPrevalidationResult(rpcMsg.topic, validationResult.code)
+    this.metrics?.onPrevalidationResult(topic, messageBytes, validationResult.code)
 
     const validationCode = validationResult.code
     switch (validationCode) {
@@ -2294,7 +2295,7 @@ export class GossipSub extends TypedEventEmitter<GossipsubEvents> implements Pub
       topic,
       tosendCount,
       tosend.size,
-      rawMsg.data != null ? rawMsg.data.length : 0,
+      RPC.Message.getSize(rawMsg),
       durationMs
     )
 

--- a/src/message/rpc.ts
+++ b/src/message/rpc.ts
@@ -190,6 +190,15 @@ export namespace RPC {
     export const decode = (buf: Uint8Array | Uint8ArrayList, opts?: DecodeOptions<Message>): Message => {
       return decodeMessage(buf, Message.codec(), opts)
     }
+
+    export const getSize = (msg: Message): number => {
+      return (msg.from?.length ?? 0) +
+        (msg.data?.length ?? 0) +
+        (msg.seqno?.length ?? 0) +
+        (msg.topic?.length ?? 0) +
+        (msg.signature?.length ?? 0) +
+        (msg.key?.length ?? 0)
+    }
   }
 
   export interface ControlMessage {


### PR DESCRIPTION
More metrics were added to `ethereum/beacon-metrics` to help track peerDAS.  There were also a couple of adds related to gossipsub so made those changes here.

**NOTE:** There is a breaking change to the metrics.  It is not an API break but the metric names changes such that dashboards will not show up correctly without changing the PromQL 

A few of the metric name changed so a PR to lodestar will need to be made when updating the dependency to modify the dashboards so they reference the updated metric names