### PR TITLE
fix: use IncomingStreamData type from interface module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,9 +75,10 @@ import type {
   Logger,
   ComponentLogger,
   Topology,
-  PrivateKey
+  PrivateKey,
+  IncomingStreamData
 } from '@libp2p/interface'
-import type { ConnectionManager, IncomingStreamData, Registrar } from '@libp2p/interface-internal'
+import type { ConnectionManager, Registrar } from '@libp2p/interface-internal'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Uint8ArrayList } from 'uint8arraylist'
 


### PR DESCRIPTION
This type is duplicated in `@libp2p/interface` and `@libp2p/interface-internal` so use the one from the interface module.

It will be removed from an upcoming `@libp2p/interface-internal` release so this is a forwards compatibility fix.