### PR TITLE
fix: cache peer ids

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1016,7 +1016,7 @@ export class GossipSub extends TypedEventEmitter<GossipsubEvents> implements Pub
    */
   getSubscribers (topic: TopicStr): PeerId[] {
     const peersInTopic = this.topics.get(topic)
-    return ((peersInTopic != null) ? Array.from(peersInTopic) : []).map((str) => this.peers.get(str)).filter((p) => p != null)
+    return ((peersInTopic != null) ? Array.from(peersInTopic) : []).map((str) => this.peers.get(str) ?? peerIdFromString(str))
   }
 
   /**
@@ -2316,7 +2316,7 @@ export class GossipSub extends TypedEventEmitter<GossipsubEvents> implements Pub
     }
 
     return {
-      recipients: Array.from(tosend.values()).map((str) => this.peers.get(str)).filter((p) => p != null)
+      recipients: Array.from(tosend.values()).map((str) => this.peers.get(str) ?? peerIdFromString(str))
     }
   }
 


### PR DESCRIPTION
- As seen here https://github.com/ChainSafe/lodestar/pull/7359#issuecomment-2761021584 `peerIdFromString` is a significant portion of runtime
- We're already tracking our peers via a `Set<PeerIdStr>`. This is easily converted to a `Map<PeerIdStr, PeerId>`, and the `PeerId` can be reused instead of recalculated. 