### PR TITLE
fix(deps-dev): Dynamic import node:events

### DIFF
--- a/test/utils/create-pubsub.ts
+++ b/test/utils/create-pubsub.ts
@@ -1,4 +1,3 @@
-import { setMaxListeners } from 'events'
 import { generateKeyPair } from '@libp2p/crypto/keys'
 import { TypedEventEmitter, start } from '@libp2p/interface'
 import { mockRegistrar, mockConnectionManager, mockNetwork } from '@libp2p/interface-compliance-tests/mocks'
@@ -55,10 +54,14 @@ export const createComponents = async (opts: CreateComponentsOpts): Promise<Goss
 
   mockNetwork.addNode(components)
 
+  let setMaxListeners: undefined | any;
   try {
     // not available everywhere
-    setMaxListeners(Infinity, pubsub)
+    setMaxListeners = (await import("node:events")).default.setMaxListeners;
   } catch {}
+  if(typeof setMaxListeners != 'undefined') {
+    setMaxListeners(Infinity, pubsub)
+  }
 
   return { pubsub, components }
 }


### PR DESCRIPTION
Avoids the following error when running `pnpm run test`:
```
test browser
ℹ Browser "chromium" setup complete.
✘ [ERROR] Could not resolve "events"

    dist/test/utils/create-pubsub.js:1:32:
      1 │ import { setMaxListeners } from 'events';
        │                                 ~~~~~~~~
        ╵                                 "./events"

  The package "events" wasn't found on the file system but is built into node. Are you trying to
  bundle for node? You can use "platform: 'node'" to do that, which will remove this error.
```

Also allows errors not related to failed imports to propagate correctly.