### PR TITLE
chore: Use floodsub factory method

### DIFF
--- a/test/e2e/go-gossipsub.spec.ts
+++ b/test/e2e/go-gossipsub.spec.ts
@@ -1,4 +1,4 @@
-import { FloodSub } from '@libp2p/floodsub'
+import { floodsub } from '@libp2p/floodsub'
 import { type Message, TopicValidatorResult, type Libp2pEvents } from '@libp2p/interface'
 import { stop } from '@libp2p/interface'
 import { mockNetwork } from '@libp2p/interface-compliance-tests/mocks'
@@ -693,7 +693,7 @@ describe('go-libp2p-pubsub gossipsub tests', function () {
     })
     const fsubs = await createComponentsArray({
       number: 10,
-      pubsub: FloodSub
+      pubsub: floodsub
     })
     psubs = gsubs.concat(fsubs)
 

--- a/test/floodsub.spec.ts
+++ b/test/floodsub.spec.ts
@@ -1,4 +1,4 @@
-import { FloodSub } from '@libp2p/floodsub'
+import { floodsub } from '@libp2p/floodsub'
 import { stop } from '@libp2p/interface'
 import { mockNetwork } from '@libp2p/interface-compliance-tests/mocks'
 import { expect } from 'aegir/chai'
@@ -23,7 +23,7 @@ describe('gossipsub fallbacks to floodsub', () => {
         }
       })
       nodeFs = await createComponents({
-        pubsub: FloodSub
+        pubsub: floodsub
       })
     })
 
@@ -61,7 +61,7 @@ describe('gossipsub fallbacks to floodsub', () => {
         }
       })
       nodeFs = await createComponents({
-        pubsub: FloodSub
+        pubsub: floodsub
       })
     })
 
@@ -97,7 +97,7 @@ describe('gossipsub fallbacks to floodsub', () => {
         }
       })
       nodeFs = await createComponents({
-        pubsub: FloodSub
+        pubsub: floodsub
       })
 
       await connectPubsubNodes(nodeGs, nodeFs)
@@ -158,7 +158,7 @@ describe('gossipsub fallbacks to floodsub', () => {
         }
       })
       nodeFs = await createComponents({
-        pubsub: FloodSub
+        pubsub: floodsub
       })
 
       await connectPubsubNodes(nodeGs, nodeFs)
@@ -227,7 +227,7 @@ describe('gossipsub fallbacks to floodsub', () => {
         }
       })
       nodeFs = await createComponents({
-        pubsub: FloodSub
+        pubsub: floodsub
       })
 
       await connectPubsubNodes(nodeGs, nodeFs)

--- a/test/utils/create-pubsub.ts
+++ b/test/utils/create-pubsub.ts
@@ -8,12 +8,13 @@ import { PersistentPeerStore } from '@libp2p/peer-store'
 import { MemoryDatastore } from 'datastore-core'
 import { stubInterface } from 'sinon-ts'
 import { GossipSub, type GossipSubComponents, type GossipsubOpts } from '../../src/index.js'
-import type { TypedEventTarget, Libp2pEvents, PubSub } from '@libp2p/interface'
+import type { TypedEventTarget, Libp2pEvents } from '@libp2p/interface'
 import type { ConnectionManager } from '@libp2p/interface-internal'
+import type { floodsub } from '@libp2p/floodsub'
 
 export interface CreateComponentsOpts {
   init?: Partial<GossipsubOpts>
-  pubsub?: { new (opts?: any): PubSub }
+  pubsub?: typeof floodsub
 }
 
 export interface GossipSubTestComponents extends GossipSubComponents {


### PR DESCRIPTION
Required since https://github.com/libp2p/js-libp2p/pull/2717 landed which no longer exports `FloodSub` from `@libp2p/floodsub`.