### PR TITLE
fix(deps)!: Upgrade node/npm engine spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "time-cache": "^0.3.0"
       },
       "engines": {
-        "npm": ">=8.7.0"
+        "node": ">=20.9.0"
       }
     },
     "node_modules/@actions/cache": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "time-cache": "^0.3.0"
   },
   "engines": {
-    "npm": ">=8.7.0"
+    "node": ">=20.9.0"
   },
   "eslintConfig": {
     "extends": "ipfs",


### PR DESCRIPTION
The engine spec applied here matches the minimum requirements of all transient dependencies (in `package-lock.json`). The engine requirement is changed from `npm` version to `node` version to better match with the engine spec discovered as outlined in the install attempts below (nobody seems to depend on npm versions, only node version).

With `engine-strict=true` in `.npmrc`, I attempted to install with old versions of node/npm, until successfully installed and tested.

Minimum spec install attempt #1:
```
$ nvm install v18.1.0
v18.1.0 is already installed.
Now using node v18.1.0 (npm v8.8.0)
$ npm install
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: @semantic-release/commit-analyzer@13.0.0
npm ERR! notsup Not compatible with your version of node/npm: @semantic-release/commit-analyzer@13.0.0
npm ERR! notsup Required: {"node":">=20.8.1"}
npm ERR! notsup Actual:   {"npm":"8.8.0","node":"v18.1.0"}
```

Minimum spec install attempt #2:
```
$ nvm install v20.8.1
v20.8.1 is already installed.
Now using node v20.8.1 (npm v10.1.0)
$ npm install
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: eslint-visitor-keys@4.0.0
npm ERR! notsup Not compatible with your version of node/npm: eslint-visitor-keys@4.0.0
npm ERR! notsup Required: {"node":"^18.18.0 || ^20.9.0 || >=21.1.0"}
npm ERR! notsup Actual:   {"npm":"10.1.0","node":"v20.8.1"}
```

Minimum spec install attempt #3:
```
$ nvm install v20.9.0
v20.9.0 is already installed.
Now using node v20.9.0 (npm v10.1.0)
$ npm install
npm WARN deprecated @humanwhocodes/config-array@0.11.14: Use @eslint/config-array instead
npm WARN deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm WARN deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm WARN deprecated glob@8.1.0: Glob versions prior to v9 are no longer supported
npm WARN deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm WARN deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported

> @chainsafe/libp2p-gossipsub@14.1.1 prepare
> npm run build

> @chainsafe/libp2p-gossipsub@14.1.1 build
> aegir build

[10:23:50] tsc [started]
[10:23:52] tsc [completed]
[10:23:52] esbuild [started]
[10:23:52] esbuild [completed]

added 219 packages, removed 312 packages, changed 607 packages, and audited 1896 packages in 14s

363 packages are looking for funding
  run `npm fund` for details

17 vulnerabilities (16 moderate, 1 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues possible (including breaking changes), run:
  npm audit fix --force

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
```

BREAKING CHANGE: Requires Node v20.9.0 or newer