### PR TITLE
fix: deliver message when publish

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2268,6 +2268,8 @@ export class GossipSub extends TypedEventEmitter<GossipsubEvents> implements Pub
     this.seenCache.put(msgIdStr)
     // all published messages are valid
     this.mcache.put({ msgId, msgIdStr }, rawMsg, true)
+    // Consider the message as delivered for gossip promises.
+    this.gossipTracer.deliverMessage(msgIdStr);
 
     // If the message is anonymous or has a random author add it to the published message ids cache.
     this.publishedMessageIds.put(msgIdStr)


### PR DESCRIPTION
**Motivation**
- mitigate the impact of p7 penalty monitored in #7849


**Description**
- when lodestar finds all blobs from EL, it publish all sampled `data_column_sidecars`, we should mark all traced messages as delivered
- same implementation in Rust: https://github.com/libp2p/rust-libp2p/blob/0e6924c77a12d8d216949e6b0e11de5a89216f04/protocols/gossipsub/src/behaviour.rs#L739