### PR TITLE
feat: Dispatch event on IHAVE received

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -239,9 +239,15 @@ export interface MeshPeer {
   direction: Direction
 }
 
+export interface GossipIHave {
+  peerId: string
+  message: RPC.ControlIHave[]
+}
+
 export interface GossipsubEvents extends PubSubEvents {
   'gossipsub:heartbeat': CustomEvent
   'gossipsub:message': CustomEvent<GossipsubMessage>
+  'gossipsub:ihave': CustomEvent<GossipIHave>
   'gossipsub:graft': CustomEvent<MeshPeer>
   'gossipsub:prune': CustomEvent<MeshPeer>
 }
@@ -1482,6 +1488,10 @@ export class GossipSub extends TypedEventEmitter<GossipsubEvents> implements Pub
       this.metrics?.ihaveRcvIgnored.inc({ reason: IHaveIgnoreReason.MaxIhave })
       return []
     }
+
+    this.safeDispatchEvent<GossipIHave>('gossipsub:ihave', {
+      detail: { peerId: id, message: ihave }
+    })
 
     const iasked = this.iasked.get(id) ?? 0
     if (iasked >= constants.GossipsubMaxIHaveLength) {


### PR DESCRIPTION
This PR adds a dispatching event when the node receives an `IHAVE` message from a peer. 
This _feature_ is useful in scenarios where, for any reason, the received message (or rather, the data message transmitted) gets lost in the future, and we need to query the peer to fetch this data using a Request/Response style protocol. 
Knowing which peers had this message/data in the first place makes these queries more _intelligent_/targeted.

Specific example:
1. Peers gossip transactions
2. Some transaction is added to the local `mempool`
3. _time passes_ and the transaction gets evicted for whatever reason
4. _time passes_  and now we need this specific tx (be it for block building, proving, serving RPC request, etc.). We have to fetch it from a peer. 
5. It would be best to query peers that we know have had this transaction at some point because they've sent us an `IHAVE` message. 