### PR TITLE
fix: fix the nosign policy validation wrong check

### DIFF
--- a/src/utils/buildRawMessage.ts
+++ b/src/utils/buildRawMessage.ts
@@ -91,7 +91,7 @@ export async function validateToRawMessage (
     case StrictNoSign:
       if (msg.signature != null) return { valid: false, error: ValidateError.SignaturePresent }
       if (msg.seqno != null) return { valid: false, error: ValidateError.SeqnoPresent }
-      if (msg.key != null) return { valid: false, error: ValidateError.FromPresent }
+      if (msg.from != null) return { valid: false, error: ValidateError.FromPresent }
 
       return { valid: true, message: { type: 'unsigned', topic: msg.topic, data: msg.data ?? new Uint8Array(0) } }
 


### PR DESCRIPTION
This pull request makes a small fix in the `validateToRawMessage` function to correctly check the presence of the `from` field instead of the `key` field when validating messages with the `StrictNoSign` option. This improves the accuracy of validation error reporting.