### PR TITLE
fix: remove duplicate pubkey conversion

### DIFF
--- a/src/utils/buildRawMessage.ts
+++ b/src/utils/buildRawMessage.ts
@@ -160,7 +160,7 @@ export async function validateToRawMessage (
           sequenceNumber: BigInt(`0x${uint8ArrayToString(msg.seqno, 'base16')}`),
           topic: msg.topic,
           signature: msg.signature,
-          key: msg.key != null ? publicKeyFromProtobuf(msg.key) : publicKey
+          key: publicKey
         }
       }
     }


### PR DESCRIPTION
This pull request makes a small change to the `validateToRawMessage` function in `src/utils/buildRawMessage.ts`, ensuring that the `key` property is always set to the provided `publicKey` rather than using `publicKeyFromProtobuf(msg.key)` again because it had been called in the previous code.