### PR TITLE
fix: prune empty topic entries from topics map

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -963,8 +963,11 @@ export class GossipSub extends TypedEventEmitter<GossipsubEvents> implements Pub
     this.streamsInbound.delete(id)
 
     // remove peer from topics map
-    for (const peers of this.topics.values()) {
+    for (const [topic, peers] of this.topics) {
       peers.delete(id)
+      if (peers.size === 0) {
+        this.topics.delete(topic)
+      }
     }
 
     // Remove this peer from the mesh
@@ -1191,17 +1194,21 @@ export class GossipSub extends TypedEventEmitter<GossipsubEvents> implements Pub
     this.log('subscription update from %p topic %s', from, topic)
 
     let topicSet = this.topics.get(topic)
-    if (topicSet == null) {
-      topicSet = new Set()
-      this.topics.set(topic, topicSet)
-    }
 
     if (subscribe) {
+      if (topicSet == null) {
+        topicSet = new Set()
+        this.topics.set(topic, topicSet)
+      }
+
       // subscribe peer to new topic
       topicSet.add(from.toString())
-    } else {
+    } else if (topicSet != null) {
       // unsubscribe from existing topic
       topicSet.delete(from.toString())
+      if (topicSet.size === 0) {
+        this.topics.delete(topic)
+      }
     }
 
     // TODO: rust-libp2p has A LOT more logic here

--- a/test/gossip.spec.ts
+++ b/test/gossip.spec.ts
@@ -269,6 +269,84 @@ describe('gossip', () => {
     expect(peerInfoB?.tags.get(topic)).to.be.undefined()
   })
 
+  it('should delete empty topic entries after remote unsubscribe', async function () {
+    this.timeout(10e4)
+    const nodeA = nodes[0]
+    const nodeB = nodes[1]
+    const topic = 'empty-topic-cleanup'
+
+    await connectAllPubSubNodes([nodeA, nodeB])
+
+    nodeA.pubsub.subscribe(topic)
+    await pEvent(nodeB.pubsub, 'subscription-change')
+
+    expect((nodeB.pubsub as any).topics.has(topic)).to.be.true()
+
+    nodeA.pubsub.unsubscribe(topic)
+    await pEvent(nodeB.pubsub, 'subscription-change')
+
+    expect(nodeB.pubsub.getSubscribers(topic)).to.be.empty()
+    expect((nodeB.pubsub as any).topics.has(topic)).to.be.false()
+  })
+
+  it('should delete empty topic entries after peer disconnect', async function () {
+    this.timeout(10e4)
+    const nodeA = nodes[0]
+    const nodeB = nodes[1]
+    const topic = 'disconnect-topic-cleanup'
+
+    await connectAllPubSubNodes([nodeA, nodeB])
+
+    nodeA.pubsub.subscribe(topic)
+    await pEvent(nodeB.pubsub, 'subscription-change')
+
+    expect((nodeB.pubsub as any).topics.has(topic)).to.be.true()
+
+    ;(nodeB.pubsub as any).onPeerDisconnected(nodeA.components.peerId)
+
+    expect(nodeB.pubsub.getSubscribers(topic)).to.be.empty()
+    expect((nodeB.pubsub as any).topics.has(topic)).to.be.false()
+  })
+
+  it('should not create empty topic entries from unsubscribe-only updates', async function () {
+    this.timeout(10e4)
+    const nodeA = nodes[0]
+    const nodeB = nodes[1]
+    const topic = 'unsubscribe-only-cleanup'
+
+    await connectAllPubSubNodes([nodeA, nodeB])
+
+    ;(nodeB.pubsub as any).handleReceivedSubscription(nodeA.components.peerId, topic, false)
+
+    expect((nodeB.pubsub as any).topics.has(topic)).to.be.false()
+    expect(nodeB.pubsub.getSubscribers(topic)).to.be.empty()
+  })
+
+  it('should keep topic entries while other peers remain subscribed', async function () {
+    this.timeout(10e4)
+    const nodeA = nodes[0]
+    const nodeB = nodes[1]
+    const nodeC = nodes[2]
+    const topic = 'multi-peer-topic-cleanup'
+
+    await connectAllPubSubNodes([nodeA, nodeB, nodeC])
+
+    nodeA.pubsub.subscribe(topic)
+    await pEvent(nodeB.pubsub, 'subscription-change')
+
+    nodeC.pubsub.subscribe(topic)
+    await pEvent(nodeB.pubsub, 'subscription-change')
+
+    expect((nodeB.pubsub as any).topics.has(topic)).to.be.true()
+    expect(nodeB.pubsub.getSubscribers(topic)).to.have.lengthOf(2)
+
+    nodeA.pubsub.unsubscribe(topic)
+    await pEvent(nodeB.pubsub, 'subscription-change')
+
+    expect((nodeB.pubsub as any).topics.has(topic)).to.be.true()
+    expect(nodeB.pubsub.getSubscribers(topic).map((p) => p.toString())).to.deep.equal([nodeC.components.peerId.toString()])
+  })
+
   it('should reject incoming messages bigger than maxInboundDataLength limit', async function () {
     this.timeout(10e4)
     const nodeA = nodes[0]

--- a/test/gossip.spec.ts
+++ b/test/gossip.spec.ts
@@ -344,7 +344,9 @@ describe('gossip', () => {
     await pEvent(nodeB.pubsub, 'subscription-change')
 
     expect((nodeB.pubsub as any).topics.has(topic)).to.be.true()
-    expect(nodeB.pubsub.getSubscribers(topic).map((p) => p.toString())).to.deep.equal([nodeC.components.peerId.toString()])
+    const subscribers = nodeB.pubsub.getSubscribers(topic).map((p) => p.toString())
+    expect(subscribers).to.have.lengthOf(1)
+    expect(subscribers).to.include(nodeC.components.peerId.toString())
   })
 
   it('should reject incoming messages bigger than maxInboundDataLength limit', async function () {


### PR DESCRIPTION
## Summary

Fix a `topics` map retention bug in gossipsub.

When a remote peer unsubscribed from a topic, or disconnected after being the last subscriber for a topic, the internal `topics: Map<TopicStr, Set<PeerIdStr>>` entry was left behind as an empty `Set`. Over time this let topic strings accumulate indefinitely.

This patch:
- prunes empty `topics` entries on remote unsubscribe
- prunes empty `topics` entries on peer disconnect
- avoids creating empty `topics` entries from unsubscribe-only updates
- adds regression tests for all of the above

Closes #542.

## Details

The minimal fix is intentionally scoped to `topics` only.

I did **not** prune `mesh` entries in the same change because `mesh` is local joined-topic state and deleting empty mesh topics on disconnect would interfere with heartbeat maintenance/regrafting. `fanout` already has TTL cleanup, and `backoff` already self-prunes empty per-topic maps.

## Testing

- `pnpm test -- --target node --grep 'topic entries|unsubscribe-only'`
- `pnpm lint`

## AI disclosure

Initial heap analysis and patch drafting were assisted by AI tooling, then validated with local source inspection and test runs.